### PR TITLE
fix: actually wait

### DIFF
--- a/R/rbabylon.R
+++ b/R/rbabylon.R
@@ -29,10 +29,11 @@ bbi_exec <- function(.cmd_args, .verbose = FALSE, .wait = FALSE, ...) {
 
   if (.wait) {
     # wait for process and capture stdout and stderr
-    output <- p$read_all_output_lines()
-
+    p$wait()
     # check output status code
     check_status_code(p$get_exit_status(), output, .cmd_args)
+    output <- p$read_all_output_lines()
+
   } else {
     output <- NULL
   }


### PR DESCRIPTION
currently this does not work as read_all_output_lines _seems_ to be non-blocking
and therefore does not wait, though the docs say it _should_ block I'm wondering if the interleaving of the stderr causes this to not wait or something?

Prior to adding this, I would get the following:

```
> res101 <- spec101 %>%
+           submit_model(.mode = "local", .wait = TRUE)
Error in if (.status_code != 0) { : argument is of length zero
```

in which the status_code error is clearly coming from the `check_status_code()` call.

By adding the explicit wait, this now works:

```
> res101 <- spec101 %>%
+           submit_model(.mode = "local", .wait = TRUE)
> res101
$process
PROCESS 'bbi', finished.

$stdout
[1] "time=\"2020-03-01T18:53:38-05:00\" level=info msg=\"Successfully loaded default configuration from /Users/devinp/clients/metrum/tech-solutions/rbabylon-example-project/model/pk/babylon.yaml\""
[2] "time=\"2020-03-01T18:53:38-05:00\" level=info msg=\"Beginning Local Path\""                                                                                                                     
[3] "time=\"2020-03-01T18:53:38-05:00\" level=info msg=\"A total of 1 models have completed the initial preparation phase\""                                                                         
[4] "time=\"2020-03-01T18:53:38-05:00\" level=info msg=\"[101] Beginning local work phase\""                                                                                                         
[5] "time=\"2020-03-01T18:54:09-05:00\" level=info msg=\"[101] Beginning cleanup phase\""                                                                                                            
[6] "time=\"2020-03-01T18:54:09-05:00\" level=info msg=\"\\r1 models completed in 30.615610931s\""                                                                                                   
[7] ""                                                                                                                                                                                               

$bbi
[1] "/Users/devinp/go/bin/bbi"

$cmd_args
[1] "nonmem"  "run"     "local"   "101.ctl"

$orig_working_dir
[1] "/Users/devinp/clients/metrum/tech-solutions/rbabylon-example-project/model/pk"

$orig_yaml_file
[1] "101.yaml"

$description
[1] "fit of Phase I data base model"

$model_type
[1] "nonmem"

$model_path
[1] "101.ctl"

$bbi_args
list()

$output_dir
[1] "101"

attr(,"class")
[1] "bbi_nonmem_result" "babylon_result"    "bbi_nonmem_spec"   "list"      
```