### PR TITLE
Get bbi on drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ steps:
   commands:
   - wget https://github.com/gruntwork-io/fetch/releases/download/v0.3.7/fetch_linux_amd64 -O fetch
   - chmod +x fetch
-  - ./fetch --repo="https://github.com/metrumresearchgroup/babylon" --tag=">2.1.0" --release-asset="releases/download/*/bbi*linux_amd64.tar.gz" bbi.tar.gz
+  - ./fetch --repo="https://github.com/metrumresearchgroup/babylon" --tag=">2.1.0" --release-asset="bbi*linux_amd64.tar.gz" bbi.tar.gz
   - tar -xzf bbi.tar.gz
   - chmod +x bbi
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -20,9 +20,7 @@ steps:
     GITHUB_OAUTH_TOKEN:
         from_secret: GITHUB_TOKEN
   commands:
-  - wget https://github.com/gruntwork-io/fetch/releases/download/v0.3.7/fetch_linux_amd64 -O fetch
-  - chmod +x fetch
-  - ./fetch --repo="https://github.com/metrumresearchgroup/babylon" --tag="v2.1.0-rc2" --release-asset="bbi*linux_amd64.tar.gz" bbi.tar.gz
+  - wget https://github.com/metrumresearchgroup/babylon/releases/download/v2.1.0-rc2/bbi_2.1.0-rc2_linux_amd64.tar.gz -O bbi.tar.gz
   - tar -xzf bbi.tar.gz
   - chmod +x bbi
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -38,6 +38,14 @@ steps:
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.5/2020-01-29"
   commands:
+  # download and setup bbi
+  - wget https://github.com/metrumresearchgroup/babylon/releases/download/v2.1.0-rc2/bbi_2.1.0-rc2_linux_amd64.tar.gz -O bbi.tar.gz
+  - tar -xzf bbi.tar.gz
+  - rm bbi.tar.gz
+  - chmod +x bbi
+  - mkdir -p /data/apps
+  - mv bbi /data/apps/bbi
+  - export PATH=/data/apps:$PATH
   # run R tests
   - /opt/R/3.5.3/bin/R -e "devtools::test()"
   - /opt/R/3.5.3/bin/R -e "devtools::check()"

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ steps:
   commands:
   - wget https://github.com/gruntwork-io/fetch/releases/download/v0.3.7/fetch_linux_amd64 -O fetch
   - chmod +x fetch
-  - ./fetch --repo="https://github.com/metrumresearchgroup/babylon" --tag=">2.1.0" --release-asset="bbi*linux_amd64.tar.gz" bbi.tar.gz
+  - ./fetch --repo="https://github.com/metrumresearchgroup/babylon" --tag="v2.1.0-rc2" --release-asset="bbi*linux_amd64.tar.gz" bbi.tar.gz
   - tar -xzf bbi.tar.gz
   - chmod +x bbi
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,27 +13,21 @@ steps:
   - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-01-29
 
 
-- name: Pull latest bbi
-  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-01-29"
-  pull: never
-  environment:
-    GITHUB_OAUTH_TOKEN:
-        from_secret: GITHUB_TOKEN
-  commands:
-  - wget https://github.com/metrumresearchgroup/babylon/releases/download/v2.1.0-rc2/bbi_2.1.0-rc2_linux_amd64.tar.gz -O bbi.tar.gz
-  - tar -xzf bbi.tar.gz
-  - chmod +x bbi
-
-
 - name: R36
   image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-01-29"
   pull: never
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.6/2020-01-29"
   commands:
+  # download and setup bbi
+  - wget https://github.com/metrumresearchgroup/babylon/releases/download/v2.1.0-rc2/bbi_2.1.0-rc2_linux_amd64.tar.gz -O bbi.tar.gz
+  - tar -xzf bbi.tar.gz
+  - rm bbi.tar.gz
+  - chmod +x bbi
   - mkdir -p /data/apps
-  - cp bbi /data/apps/bbi
+  - mv bbi /data/apps/bbi
   - export PATH=/data/apps:$PATH
+  # run R tests
   - /opt/R/3.6.2/bin/R -e "devtools::test()"
   - /opt/R/3.6.2/bin/R -e "devtools::check()"
 
@@ -43,10 +37,18 @@ steps:
   pull: never
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.5/2020-01-29"
+    GITHUB_OAUTH_TOKEN:
+        from_secret: GITHUB_TOKEN
   commands:
+  # download and setup bbi
+  - wget https://github.com/metrumresearchgroup/babylon/releases/download/v2.1.0-rc2/bbi_2.1.0-rc2_linux_amd64.tar.gz -O bbi.tar.gz
+  - tar -xzf bbi.tar.gz
+  - rm bbi.tar.gz
+  - chmod +x bbi
   - mkdir -p /data/apps
-  - cp bbi /data/apps/bbi
+  - mv bbi /data/apps/bbi
   - export PATH=/data/apps:$PATH
+  # run R tests
   - /opt/R/3.5.3/bin/R -e "devtools::test()"
   - /opt/R/3.5.3/bin/R -e "devtools::check()"
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,7 +32,7 @@ steps:
   pull: never
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.6/2020-01-29"
-    PATH: "/data/apps":$PATH
+    PATH: "/data/apps:$PATH"
   commands:
   - mkdir -p /data/apps
   - cp bbi /data/apps/bbi
@@ -45,7 +45,7 @@ steps:
   pull: never
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.5/2020-01-29"
-    PATH: "/data/apps":$PATH
+    PATH: "/data/apps:$PATH"
   commands:
   - mkdir -p /data/apps
   - cp bbi /data/apps/bbi

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,10 +30,10 @@ steps:
   pull: never
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.6/2020-01-29"
-    PATH: "/data/apps:${PATH}"
   commands:
   - mkdir -p /data/apps
   - cp bbi /data/apps/bbi
+  - export PATH=/data/apps:$PATH
   - /opt/R/3.6.2/bin/R -e "devtools::test()"
   - /opt/R/3.6.2/bin/R -e "devtools::check()"
 
@@ -43,10 +43,10 @@ steps:
   pull: never
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.5/2020-01-29"
-    PATH: "/data/apps:$PATH"
   commands:
   - mkdir -p /data/apps
   - cp bbi /data/apps/bbi
+  - export PATH=/data/apps:$PATH
   - /opt/R/3.5.3/bin/R -e "devtools::test()"
   - /opt/R/3.5.3/bin/R -e "devtools::check()"
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 kind: pipeline
 type: docker
-name: pmplots
+name: rbabylon
 
 steps:
 - name: Pull mpn container from ECR
@@ -12,12 +12,30 @@ steps:
   - $(aws ecr get-login --no-include-email --region us-east-1)
   - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-01-29
 
+
+- name: Pull latest bbi
+  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-01-29"
+  pull: never
+  environment:
+    GITHUB_OAUTH_TOKEN:
+        from_secret: GITHUB_TOKEN
+  commands:
+  - wget https://github.com/gruntwork-io/fetch/releases/download/v0.3.7/fetch_linux_amd64 -O fetch
+  - chmod +x fetch
+  - ./fetch --repo="https://github.com/metrumresearchgroup/babylon" --tag=">2.1.0" --release-asset="releases/download/*/bbi*linux_amd64.tar.gz" bbi.tar.gz
+  - tar -xzf bbi.tar.gz
+  - chmod +x bbi
+
+
 - name: R36
   image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn:2020-01-29"
   pull: never
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.6/2020-01-29"
+    PATH: "/data/apps":$PATH
   commands:
+  - mkdir -p /data/apps
+  - cp bbi /data/apps/bbi
   - /opt/R/3.6.2/bin/R -e "devtools::test()"
   - /opt/R/3.6.2/bin/R -e "devtools::check()"
 
@@ -27,7 +45,10 @@ steps:
   pull: never
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.5/2020-01-29"
+    PATH: "/data/apps":$PATH
   commands:
+  - mkdir -p /data/apps
+  - cp bbi /data/apps/bbi
   - /opt/R/3.5.3/bin/R -e "devtools::test()"
   - /opt/R/3.5.3/bin/R -e "devtools::check()"
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -37,17 +37,7 @@ steps:
   pull: never
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.5/2020-01-29"
-    GITHUB_OAUTH_TOKEN:
-        from_secret: GITHUB_TOKEN
   commands:
-  # download and setup bbi
-  - wget https://github.com/metrumresearchgroup/babylon/releases/download/v2.1.0-rc2/bbi_2.1.0-rc2_linux_amd64.tar.gz -O bbi.tar.gz
-  - tar -xzf bbi.tar.gz
-  - rm bbi.tar.gz
-  - chmod +x bbi
-  - mkdir -p /data/apps
-  - mv bbi /data/apps/bbi
-  - export PATH=/data/apps:$PATH
   # run R tests
   - /opt/R/3.5.3/bin/R -e "devtools::test()"
   - /opt/R/3.5.3/bin/R -e "devtools::check()"

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,7 +30,7 @@ steps:
   pull: never
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.6/2020-01-29"
-    PATH: "/data/apps:$PATH"
+    PATH: "/data/apps:${PATH}"
   commands:
   - mkdir -p /data/apps
   - cp bbi /data/apps/bbi

--- a/tests/testthat/test-rbabylon.R
+++ b/tests/testthat/test-rbabylon.R
@@ -13,63 +13,6 @@ test_that("check_status_code works as expected", {
   expect_error(check_status_code(225, "stdout...", c("arg1", "arg2")))
 })
 
-test_that("check_bbi_exe() correctly errors or finds paths", {
-  FAKE_BBI_PATH <- "/tmp/fake/bbi"
-
-  # should fail because path doesn't exist
-  expect_error(check_bbi_exe(FAKE_BBI_PATH))
-
-  # should pass because ping should exist on Metworx (and most Linux/Unix)
-  # if (Sys.getenv("METWORX_VERSION") == "") {
-  #   skip("only check for ping on Metworx")
-  # } else {
-  #   expect_invisible(check_bbi_exe("ping"))
-  # }
-  expect_invisible(check_bbi_exe(BBI_EXE_PATH))
-})
-
-
-test_that("bbi_init creates babylon.yaml", {
-  # create yaml
-  # if (Sys.getenv("METWORX_VERSION") == "") {
-  #   skip("bbi_init only runs on Metworx")
-  # } else {
-  #   withr::with_options(list(rbabylon.bbi_exe_path = BBI_EXE_PATH), {
-  #     bbi_init(".", ".", .no_default_version=TRUE)
-  #   })
-  # }
-  withr::with_options(list(rbabylon.bbi_exe_path = BBI_EXE_PATH), {
-    bbi_init(".", ".", .no_default_version=TRUE)
-  })
-
-  # read in yaml and check that it has a babylon key
-  bbi_yaml <- yaml::read_yaml("babylon.yaml")
-  expect_true("babylon_binary" %in% names(bbi_yaml))
-
-  # delete yaml
-  fs::file_delete("babylon.yaml")
-
-})
-
-test_that("bbi_init errors with invalid .nonmem_version", {
-  # fails if don't specify anything
-  expect_error(bbi_init(".", "."), regexp = "Must specify a `.nonmem_version`")
-
-  # fails if what you specify isn't in the babylon.yaml (i.e. isn't a valid NONMEM installation)
-  # if (Sys.getenv("METWORX_VERSION") == "") {
-  #   skip("bbi_init only runs on Metworx")
-  # } else {
-  #   withr::with_options(list(rbabylon.bbi_exe_path = BBI_EXE_PATH), {
-  #     expect_error(bbi_init(".", ".", "naw"), regexp = "Must specify a valid `.nonmem_version`")
-  #     fs::file_delete("babylon.yaml")
-  #   })
-  # }
-  withr::with_options(list(rbabylon.bbi_exe_path = BBI_EXE_PATH), {
-    expect_error(bbi_init(".", ".", "naw"), regexp = "Must specify a valid `.nonmem_version`")
-    fs::file_delete("babylon.yaml")
-  })
-})
-
 
 test_that("bbi_dry_run() correctly returns object", {
   PROC_CLASS_LIST <- c("babylon_process", "list")
@@ -87,3 +30,46 @@ test_that("bbi_dry_run() correctly returns object", {
   expect_identical(res[[PROC_WD]], dir)
   expect_identical(class(res), PROC_CLASS_LIST)
 })
+
+
+if (Sys.getenv("METWORX_VERSION") == "" && !isTRUE(Sys.getenv("DRONE"))) {
+  skip("bbi tests only run on Metworx or Drone")
+} else {
+  test_that("check_bbi_exe() correctly errors or finds paths", {
+    FAKE_BBI_PATH <- "/tmp/fake/bbi"
+
+    # should fail because path doesn't exist
+    expect_error(check_bbi_exe(FAKE_BBI_PATH))
+
+    # should pass because ping should exist on Metworx (and most Linux/Unix)
+    expect_invisible(check_bbi_exe(BBI_EXE_PATH))
+  })
+
+
+  test_that("bbi_init creates babylon.yaml", {
+    # create yaml
+    withr::with_options(list(rbabylon.bbi_exe_path = BBI_EXE_PATH), {
+      bbi_init(".", ".", .no_default_version=TRUE)
+    })
+
+    # read in yaml and check that it has a babylon key
+    bbi_yaml <- yaml::read_yaml("babylon.yaml")
+    expect_true("babylon_binary" %in% names(bbi_yaml))
+
+    # delete yaml
+    fs::file_delete("babylon.yaml")
+
+  })
+
+  test_that("bbi_init errors with invalid .nonmem_version", {
+    # fails if don't specify anything
+    expect_error(bbi_init(".", "."), regexp = "Must specify a `.nonmem_version`")
+
+    # fails if what you specify isn't in the babylon.yaml (i.e. isn't a valid NONMEM installation)
+    withr::with_options(list(rbabylon.bbi_exe_path = BBI_EXE_PATH), {
+      expect_error(bbi_init(".", ".", "naw"), regexp = "Must specify a valid `.nonmem_version`")
+      fs::file_delete("babylon.yaml")
+    })
+  })
+}
+

--- a/tests/testthat/test-rbabylon.R
+++ b/tests/testthat/test-rbabylon.R
@@ -1,5 +1,8 @@
 context("rbabylon exec functions")
 
+# constants
+BBI_EXE_PATH <- "/data/apps/bbi"
+
 test_that("check_status_code works as expected", {
   # nothing happens on status 0
   expect_equal(check_status_code(0, "stdout...", c("arg1", "arg2")), NULL)
@@ -17,23 +20,27 @@ test_that("check_bbi_exe() correctly errors or finds paths", {
   expect_error(check_bbi_exe(FAKE_BBI_PATH))
 
   # should pass because ping should exist on Metworx (and most Linux/Unix)
-  if (Sys.getenv("METWORX_VERSION") == "") {
-    skip("only check for ping on Metworx")
-  } else {
-    expect_invisible(check_bbi_exe("ping"))
-  }
+  # if (Sys.getenv("METWORX_VERSION") == "") {
+  #   skip("only check for ping on Metworx")
+  # } else {
+  #   expect_invisible(check_bbi_exe("ping"))
+  # }
+  expect_invisible(check_bbi_exe(BBI_EXE_PATH))
 })
 
 
 test_that("bbi_init creates babylon.yaml", {
   # create yaml
-  if (Sys.getenv("METWORX_VERSION") == "") {
-    skip("bbi_init only runs on Metworx")
-  } else {
-    withr::with_options(list(rbabylon.bbi_exe_path = '/data/apps/bbi'), {
-      bbi_init(".", ".", .no_default_version=TRUE)
-    })
-  }
+  # if (Sys.getenv("METWORX_VERSION") == "") {
+  #   skip("bbi_init only runs on Metworx")
+  # } else {
+  #   withr::with_options(list(rbabylon.bbi_exe_path = BBI_EXE_PATH), {
+  #     bbi_init(".", ".", .no_default_version=TRUE)
+  #   })
+  # }
+  withr::with_options(list(rbabylon.bbi_exe_path = BBI_EXE_PATH), {
+    bbi_init(".", ".", .no_default_version=TRUE)
+  })
 
   # read in yaml and check that it has a babylon key
   bbi_yaml <- yaml::read_yaml("babylon.yaml")
@@ -49,14 +56,18 @@ test_that("bbi_init errors with invalid .nonmem_version", {
   expect_error(bbi_init(".", "."), regexp = "Must specify a `.nonmem_version`")
 
   # fails if what you specify isn't in the babylon.yaml (i.e. isn't a valid NONMEM installation)
-  if (Sys.getenv("METWORX_VERSION") == "") {
-    skip("bbi_init only runs on Metworx")
-  } else {
-    withr::with_options(list(rbabylon.bbi_exe_path = '/data/apps/bbi'), {
-      expect_error(bbi_init(".", ".", "naw"), regexp = "Must specify a valid `.nonmem_version`")
-      fs::file_delete("babylon.yaml")
-    })
-  }
+  # if (Sys.getenv("METWORX_VERSION") == "") {
+  #   skip("bbi_init only runs on Metworx")
+  # } else {
+  #   withr::with_options(list(rbabylon.bbi_exe_path = BBI_EXE_PATH), {
+  #     expect_error(bbi_init(".", ".", "naw"), regexp = "Must specify a valid `.nonmem_version`")
+  #     fs::file_delete("babylon.yaml")
+  #   })
+  # }
+  withr::with_options(list(rbabylon.bbi_exe_path = BBI_EXE_PATH), {
+    expect_error(bbi_init(".", ".", "naw"), regexp = "Must specify a valid `.nonmem_version`")
+    fs::file_delete("babylon.yaml")
+  })
 })
 
 

--- a/tests/testthat/test-rbabylon.R
+++ b/tests/testthat/test-rbabylon.R
@@ -32,7 +32,7 @@ test_that("bbi_dry_run() correctly returns object", {
 })
 
 
-if (Sys.getenv("METWORX_VERSION") == "" && !isTRUE(Sys.getenv("DRONE"))) {
+if (Sys.getenv("METWORX_VERSION") == "" && Sys.getenv("DRONE") != "true") {
   skip("bbi tests only run on Metworx or Drone")
 } else {
   test_that("check_bbi_exe() correctly errors or finds paths", {

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -1,6 +1,6 @@
 context("Test bbi summary functions")
 
-if (Sys.getenv("METWORX_VERSION") == "" && !isTRUE(Sys.getenv("DRONE"))) {
+if (Sys.getenv("METWORX_VERSION") == "" && Sys.getenv("DRONE") != "true") {
   skip("test-summary only runs on Metworx or Drone")
 }
 

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -1,8 +1,8 @@
 context("Test bbi summary functions")
 
-# if (Sys.getenv("METWORX_VERSION") == "") {
-#   skip("test-summary only runs on Metworx")
-# }
+if (Sys.getenv("METWORX_VERSION") == "" && !isTRUE(Sys.getenv("DRONE"))) {
+  skip("test-summary only runs on Metworx or Drone")
+}
 
 # constants
 MODEL_FILE <- "1.ctl"

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -1,11 +1,8 @@
 context("Test bbi summary functions")
 
-if (Sys.getenv("METWORX_VERSION") == "") {
-  skip("test-summary only runs on Metworx")
-}
-
-withr::with_options(list(rbabylon.bbi_exe_path = '/data/apps/bbi',
-                         rbabylon.model_directory = NULL), {
+# if (Sys.getenv("METWORX_VERSION") == "") {
+#   skip("test-summary only runs on Metworx")
+# }
 
 # constants
 MODEL_FILE <- "1.ctl"
@@ -21,26 +18,16 @@ NOT_FINISHED_ERR_MSG <- "nonmem_summary.*modeling run has not finished"
 NO_LST_ERR_MSG <- "Unable to locate `.lst` file.*NONMEM output folder"
 
 
-#########################################
-# extracting things from summary object
-#########################################
+withr::with_options(list(rbabylon.bbi_exe_path = '/data/apps/bbi',
+                         rbabylon.model_directory = NULL), {
 
-test_that("model_summary.bbi_nonmem_model produces expected output", {
-  # get summary
-  sum1 <- MOD1 %>% model_summary()
+  #########################################
+  # extracting things from summary object
+  #########################################
 
-  # check class
-  expect_identical(class(sum1), SUM_CLASS_LIST)
-
-  # compare to reference
-  ref_sum <- readRDS("data/acop_summary_obj_ref_200305.rds")
-  expect_equal(ref_sum, sum1)
-})
-
-withr::with_options(list(rbabylon.model_directory = "model-examples"), {
-  test_that("model_summary.character produces expected output", {
+  test_that("model_summary.bbi_nonmem_model produces expected output", {
     # get summary
-    sum1 <- "1" %>% model_summary()
+    sum1 <- MOD1 %>% model_summary()
 
     # check class
     expect_identical(class(sum1), SUM_CLASS_LIST)
@@ -50,76 +37,89 @@ withr::with_options(list(rbabylon.model_directory = "model-examples"), {
     expect_equal(ref_sum, sum1)
   })
 
-  test_that("model_summary.numeric produces expected output", {
-    # get summary
-    sum1 <- 1 %>% model_summary()
+  withr::with_options(list(rbabylon.model_directory = "model-examples"), {
+    test_that("model_summary.character produces expected output", {
+      # get summary
+      sum1 <- "1" %>% model_summary()
 
-    # check class
-    expect_identical(class(sum1), SUM_CLASS_LIST)
+      # check class
+      expect_identical(class(sum1), SUM_CLASS_LIST)
+
+      # compare to reference
+      ref_sum <- readRDS("data/acop_summary_obj_ref_200305.rds")
+      expect_equal(ref_sum, sum1)
+    })
+
+    test_that("model_summary.numeric produces expected output", {
+      # get summary
+      sum1 <- 1 %>% model_summary()
+
+      # check class
+      expect_identical(class(sum1), SUM_CLASS_LIST)
+
+      # compare to reference
+      ref_sum <- readRDS("data/acop_summary_obj_ref_200305.rds")
+      expect_equal(ref_sum, sum1)
+    })
+  })
+
+  test_that("model_summary() fails predictably if it can't find some parts (i.e. model isn't finished)", {
+    # create new model
+    mod2 <- MOD1 %>% copy_model_from(MOD2_PATH, .description = "number 2")
+
+    # copy output directory (to simulate model run)
+    fs::dir_copy(MOD1_PATH, MOD2_PATH)
+
+    # delete a necessary file
+    fs::file_delete(file.path(MOD2_PATH, "1.ext"))
+
+    # try to run and expect error with NOT_FINISHED_ERR_MSG
+    expect_error(model_summary(mod2), regexp = NOT_FINISHED_ERR_MSG)
+
+    # cleanup
+    fs::dir_delete(MOD2_PATH)
+    fs::file_delete(ctl_ext(MOD2_PATH))
+    fs::file_delete(yaml_ext(MOD2_PATH))
+  })
+
+  test_that("model_summary() fails predictably if no .lst file present", {
+    # create new model
+    mod2 <- MOD1 %>% copy_model_from(MOD2_PATH, .description = "number 2")
+
+    # copy output directory (to simulate model run)
+    fs::dir_copy(MOD1_PATH, MOD2_PATH)
+
+    # delete a necessary file
+    fs::file_delete(file.path(MOD2_PATH, "1.lst"))
+
+    # try to run and expect error with NOT_FINISHED_ERR_MSG
+    expect_error(model_summary(mod2), regexp = NO_LST_ERR_MSG)
+
+    # cleanup
+    fs::dir_delete(MOD2_PATH)
+    fs::file_delete(ctl_ext(MOD2_PATH))
+    fs::file_delete(yaml_ext(MOD2_PATH))
+  })
+
+
+  #########################################
+  # extracting things from summary object
+  #########################################
+
+  test_that("param_estimates() gets expected table", {
+    # get summary
+    sum1 <- MOD1 %>% model_summary()
+
+    # extract parameter df
+    par_df1 <- param_estimates(sum1)
 
     # compare to reference
-    ref_sum <- readRDS("data/acop_summary_obj_ref_200305.rds")
-    expect_equal(ref_sum, sum1)
+    ref_df <- readRDS("data/acop_param_table_ref_200228.rds")
+
+    # for some arcane reason `expect_equal(par_df1, ref_df)` fails, so we just check a few columns
+    expect_true(all(par_df1$names == ref_df$names))
+    expect_true(all(round(par_df1$estimate, 2) == round(ref_df$estimate, 2)))
+    expect_true(all(par_df1$fixed == ref_df$fixed))
   })
-})
 
-test_that("model_summary() fails predictably if it can't find some parts (i.e. model isn't finished)", {
-  # create new model
-  mod2 <- MOD1 %>% copy_model_from(MOD2_PATH, .description = "number 2")
-
-  # copy output directory (to simulate model run)
-  fs::dir_copy(MOD1_PATH, MOD2_PATH)
-
-  # delete a necessary file
-  fs::file_delete(file.path(MOD2_PATH, "1.ext"))
-
-  # try to run and expect error with NOT_FINISHED_ERR_MSG
-  expect_error(model_summary(mod2), regexp = NOT_FINISHED_ERR_MSG)
-
-  # cleanup
-  fs::dir_delete(MOD2_PATH)
-  fs::file_delete(ctl_ext(MOD2_PATH))
-  fs::file_delete(yaml_ext(MOD2_PATH))
-})
-
-test_that("model_summary() fails predictably if no .lst file present", {
-  # create new model
-  mod2 <- MOD1 %>% copy_model_from(MOD2_PATH, .description = "number 2")
-
-  # copy output directory (to simulate model run)
-  fs::dir_copy(MOD1_PATH, MOD2_PATH)
-
-  # delete a necessary file
-  fs::file_delete(file.path(MOD2_PATH, "1.lst"))
-
-  # try to run and expect error with NOT_FINISHED_ERR_MSG
-  expect_error(model_summary(mod2), regexp = NO_LST_ERR_MSG)
-
-  # cleanup
-  fs::dir_delete(MOD2_PATH)
-  fs::file_delete(ctl_ext(MOD2_PATH))
-  fs::file_delete(yaml_ext(MOD2_PATH))
-})
-
-
-#########################################
-# extracting things from summary object
-#########################################
-
-test_that("param_estimates() gets expected table", {
-  # get summary
-  sum1 <- MOD1 %>% model_summary()
-
-  # extract parameter df
-  par_df1 <- param_estimates(sum1)
-
-  # compare to reference
-  ref_df <- readRDS("data/acop_param_table_ref_200228.rds")
-
-  # for some arcane reason `expect_equal(par_df1, ref_df)` fails, so we just check a few columns
-  expect_true(all(par_df1$names == ref_df$names))
-  expect_true(all(round(par_df1$estimate, 2) == round(ref_df$estimate, 2)))
-  expect_true(all(par_df1$fixed == ref_df$fixed))
-})
-
-})
+}) # closing withr::with_options


### PR DESCRIPTION
# Summary
This PR installs bbi on Drone and runs the tests that use it, except for the one test file that also uses NONMEM. That one (`tests/testthat/test-workflow-composable-bbi.R`) only runs on Metworx.

# Tests
- tests/testthat/test-rbabylon.R
  - check_bbi_exe() correctly errors or finds paths
  - bbi_init creates babylon.yaml
  - bbi_init errors with invalid .nonmem_version
- tests/testthat/test-summary.R
  - model_summary.bbi_nonmem_model produces expected output
  - model_summary.character produces expected output
  - model_summary.numeric produces expected output
  - model_summary() fails predictably if it can't find some parts (i.e. model isn't finished)
  - model_summary() fails predictably if no .lst file present
  - param_estimates() gets expected table