### PR TITLE
[do not merge] Feat/new ci images

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -21,7 +21,7 @@ local r_env_vars = {
 local mpn_snapshots = [
   "cran-latest",
   "2020-05-27",
-  "2020-03-24",
+  "v1.3",
 ];
 
 # set to "" to disable installing babylon

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,10 +15,10 @@ steps:
     path: /var/run/docker.sock
   commands:
   - $(aws ecr get-login --no-include-email --region us-east-1)
-  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn-dev:cran-latest
+  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn-dev:v1.3
 
 - name: R40
-  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn-dev:cran-latest"
+  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn-dev:v1.3"
   pull: never
   environment:
     R_LIBS_USER: "/opt/rpkgs/4.0"
@@ -35,9 +35,9 @@ steps:
   - ls -la /data/apps
   - /data/apps/bbi -h
   - export PATH=/data/apps:$PATH
-  - /opt/R/4.0.1/bin/R -e "devtools::install_deps(upgrade = 'never')"
-  - /opt/R/4.0.1/bin/R -e "devtools::test()"
-  - /opt/R/4.0.1/bin/R -e "devtools::check()"
+  - /opt/R/4.0.2/bin/R -e "devtools::install_deps(upgrade = 'never')"
+  - /opt/R/4.0.2/bin/R -e "devtools::test()"
+  - /opt/R/4.0.2/bin/R -e "devtools::check()"
 
 volumes:
 - name: docker.sock
@@ -63,10 +63,10 @@ steps:
     path: /var/run/docker.sock
   commands:
   - $(aws ecr get-login --no-include-email --region us-east-1)
-  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn-dev:cran-latest
+  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn-dev:v1.3
 
 - name: R36
-  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn-dev:cran-latest"
+  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn-dev:v1.3"
   pull: never
   environment:
     R_LIBS_USER: "/opt/rpkgs/3.6"


### PR DESCRIPTION
This PR will point Drone at the new CI images. `v1.3` is used for initial testing.

- With the new images, we will abstract away the specific R patch versions. The major.minor version will be specified, and Drone will use environment variables in the image to resolve the patch version.

- This PR also includes a lint step. Bringing the package into compliance with the default linters will take some effort, so we can either do the investment now, temporarily disable this step, or accept an overall failing status on the pipeline until we do.

**This PR should not be merged until the new set of CI images is built.**

FYI @evol262 @bkyoung @dpastoor 