### PR TITLE
param_estimates() should error on Bayesian methods

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -133,6 +133,7 @@ SUMMARY_HEURISTICS <- "run_heuristics"
 SUMMARY_COND_NUM <- "condition_number"
 SUMMARY_PARAM_NAMES <- "parameter_names"
 SUMMARY_PARAM_DATA <- "parameters_data"
+SUMMARY_EST_METHOD <- "estimation_method"
 
 # keys required for a summary object to have
 SUMMARY_REQ_KEYS <- c(

--- a/R/param-estimates.R
+++ b/R/param-estimates.R
@@ -8,6 +8,12 @@
 #' Returns a tibble containing parameter estimates from a `bbi_{.model_type}_summary` object.
 #' Details about the tibble that is returned are in the return value section below.
 #'
+#' @details
+#' Note that **Bayesian methods are not yet supported** by this function. Creating a parameter table
+#' like this for Bayesian estimation methods requires a different approach, which has not yet been
+#' implemented. If the final estimation method of the input model is Bayesian, a `not implemented`
+#' error will be thrown.
+#'
 #' @return
 #' Returns a tibble with the following columns:
 #'
@@ -31,10 +37,17 @@ param_estimates <- function(.summary) {
 #' @importFrom tibble tibble as_tibble
 #' @importFrom purrr map_at map_depth map_lgl
 #' @importFrom rlang list2
+#' @importFrom stringr str_detect
 #' @export
 param_estimates.bbi_nonmem_summary <- function(.summary) {
   num_methods <- length(.summary[[SUMMARY_PARAM_DATA]])
   param_names <- .summary[[SUMMARY_PARAM_NAMES]]
+
+  # if Bayesian method (includes NUTS) do not return df because it is incorrect and misleading
+  est_method <- .summary[[SUMMARY_DETAILS]][[SUMMARY_EST_METHOD]][[num_methods]]
+  if (str_detect(est_method, "Bayesian")) {
+    stop(glue("param_estimates() is not currently implemented for Bayesian methods. Passed has final estimation method: {est_method}"), call. = FALSE)
+  }
 
   summary_vars <- with(
     .summary[[SUMMARY_PARAM_DATA]][[num_methods]],

--- a/man/param_estimates.Rd
+++ b/man/param_estimates.Rd
@@ -28,6 +28,12 @@ Returns a tibble with the following columns:
 Returns a tibble containing parameter estimates from a \verb{bbi_\{.model_type\}_summary} object.
 Details about the tibble that is returned are in the return value section below.
 }
+\details{
+Note that \strong{Bayesian methods are not yet supported} by this function. Creating a parameter table
+like this for Bayesian estimation methods requires a different approach, which has not yet been
+implemented. If the final estimation method of the input model is Bayesian, a \verb{not implemented}
+error will be thrown.
+}
 \section{Methods (by class)}{
 \itemize{
 \item \code{bbi_nonmem_summary}: Takes \code{bbi_nonmem_summary} object, the output of \code{\link[=model_summary.bbi_nonmem_model]{model_summary.bbi_nonmem_model()}}.

--- a/tests/testthat/test-param-estimates.R
+++ b/tests/testthat/test-param-estimates.R
@@ -6,10 +6,6 @@ if (Sys.getenv("METWORX_VERSION") == "" && Sys.getenv("DRONE") != "true") {
 
 setup({
   cleanup()
-  invisible(copy_model_from(yaml_ext(MOD1_PATH), NEW_MOD2, "model from test-param-estimates.R", .directory = "."))
-  invisible(copy_model_from(yaml_ext(MOD1_PATH), NEW_MOD3, "model from test-param-estimates.R", .directory = "."))
-  fs::dir_copy(MOD1_PATH, NEW_MOD2)
-  fs::dir_copy(MOD1_PATH, NEW_MOD3)
 })
 teardown({
   cleanup()
@@ -30,6 +26,15 @@ withr::with_options(list(rbabylon.bbi_exe_path = read_bbi_path(),
     expect_true(all(par_df$parameter_names == ref_df1$parameter_names))
     expect_true(all(round(par_df$estimate, 2) == round(ref_df1$estimate, 2)))
     expect_true(all(par_df$fixed == ref_df1$fixed))
+  })
+
+  test_that("param_estimates correctly errors on Bayesian model", {
+    expect_error(
+      par_df <- 1001 %>%
+        model_summary(.directory = MODEL_DIR_X, .bbi_args = list(ext_file = "1001.1.TXT")) %>%
+        param_estimates(),
+      regexp = "not currently implemented for Bayesian methods"
+    )
   })
 
 }) # closing withr::with_options


### PR DESCRIPTION
In working on #119 it was decided that the `param_estimates()` function does not return usable results for Bayesian estimation methods. Because the returned results could actually be wrong and misleading, it was decided (in [this thread](https://github.com/metrumresearchgroup/rbabylon/issues/119#issuecomment-690290391)) that the function should error with some "not implemented" message for the time being.

There is a plan to work on this in the next few months so that `param_estimates()` gives a correct result for Bayesian methods too. @timwaterhouse may be involved in that effort.

Implementation note: all the relevant methods will have `"Bayesian"` in the string contained in `bbi_nonmem_summary$run_details$estimation_method` so we can use that to determine if we should error.