### PR TITLE
test: putting run_log malformed YAML test in its own folder

### DIFF
--- a/tests/testthat/test-run-log.R
+++ b/tests/testthat/test-run-log.R
@@ -14,11 +14,11 @@ withr::with_options(list(rbabylon.model_directory = NULL), {
   })
 
   test_that("run_log() errors with malformed YAML", {
-    temp_dir <- tempdir()
+    temp_dir <- file.path(tempdir(), "run_log_malformed_yaml_test")
+    fs::dir_create(temp_dir)
     temp_yaml <- fs::file_copy("test-yaml/zz_fail_no_modtype.yaml", temp_dir)
     on.exit({
-      fs::file_delete(temp_yaml)
-      fs::file_delete(file.path(temp_dir, basename(YAML_TEST_FILE)))
+      fs::dir_delete(temp_dir)
     })
 
     expect_warning(log_df <- run_log(temp_dir), "do not contain required keys")


### PR DESCRIPTION
For some reason this test is failing on my Metworx (on the destination branch) but not in Drone. Specifically, this fails `expect_true(nrow(log_df) == 0L)`. 

When I add a `browser()` and inspect the tibble, I see the following models existing in that folder (which is `tempdir()`).
```
log_df$absolute_model_path
 [1] "/tmp/RtmpHHSSQ2/rbabylon.Rcheck/00_pkg_src/rbabylon/inst/param_examples/510"                               
 [2] "/tmp/RtmpHHSSQ2/rbabylon.Rcheck/00_pkg_src/rbabylon/tests/testthat/model-examples/1"                       
 [3] "/tmp/RtmpHHSSQ2/rbabylon.Rcheck/00_pkg_src/rbabylon/tests/testthat/model-examples-complex/1001"            
 [4] "/tmp/RtmpHHSSQ2/rbabylon.Rcheck/00_pkg_src/rbabylon/tests/testthat/model-examples-complex/example2_saemimp"
 [5] "/tmp/RtmpHHSSQ2/rbabylon.Rcheck/00_pkg_src/rbabylon/tests/testthat/model-examples-complex/iovmm"           
 [6] "/tmp/RtmpHHSSQ2/rbabylon.Rcheck/rbabylon/nonmem/1"                                                         
 [7] "/tmp/RtmpHHSSQ2/rbabylon.Rcheck/rbabylon/param_examples/510"                                               
 [8] "/tmp/RtmpHHSSQ2/rbabylon.Rcheck/tests/testthat/model-examples/1"                                           
 [9] "/tmp/RtmpHHSSQ2/rbabylon.Rcheck/tests/testthat/model-examples-complex/1001"                                
[10] "/tmp/RtmpHHSSQ2/rbabylon.Rcheck/tests/testthat/model-examples-complex/example2_saemimp"                    
[11] "/tmp/RtmpHHSSQ2/rbabylon.Rcheck/tests/testthat/model-examples-complex/iovmm"  
```
I restarted my session several times and called `test` and `check` both on the console and with the GUI buttons, and still got this issue. 

I'm not sure why this is happening, _but_ regardless of the reason for those files being there, tests should not depend on some external state (in this case, the `tempdir()` being clean) and this change fixes that dependency.