### PR TITLE
docs: update NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,15 +6,28 @@
   `summary_log()` (#227).
 
 * The `.directory` argument is removed from `copy_model_from()`, 
-  `model_summaries()`, `model_summary()`, `new_model()`, and `read_model()` 
-  (#217, #222, #224, #226).
+  `model_summaries()`, `model_summary()`, `new_model()`, `read_model()`, 
+  `submit_model()`, and `submit_models()` (#217, #222, #224, #225, #226).
+  
+* The `.new_model` argument to `copy_model_from()` can be either an absolute 
+  path or relative to the location of `.parent_mod` (previously, the path was 
+  constructed with `.directory`) (#222).
 
-* The `.yaml_path` argument to `new_model()` becomes `.path` to reflect that a
-  single path identifies the output directory and the model and YAML files 
-  (without extension). `new_model()` and `read_model()` throw an error if a 
-  model file is not found at `.path` (#217).
+* The `.yaml_path` argument to `new_model()` becomes `.path`, and the 
+  `.model_path` argument is removed, to reflect that a single path identifies 
+  the output directory and the model and YAML files (without extension). 
+  `new_model()` and `read_model()` throw an error if a model file is not found
+  at `.path` plus any relevant file extension, e.g., `ctl` or `mod` for NONMEM 
+  (#213, #217).
+  
+* The default value of the `.config_path` argument to `submit_model()` and 
+  `submit_models()` changes to `NULL`, in which case the function will look for
+  a `babylon.yaml` in the same directory as the model file (#228).
   
 ### Removed
+
+* `get_model_directory()` and `set_model_directory()` have been removed because
+  the `rbabylon.model_directory` option is no longer used (#229).
 
 * `as_model()` has been removed because it was not used (#194).
 
@@ -25,9 +38,6 @@
   
 * `get_path_from_object()` has been removed and replaced by equivalent 
   functionality, e.g., `get_model_path()` (#195).
-
-* `get_model_directory()` and `set_model_directory()` have been removed because
-  the `rbabylon.model_directory` option is no longer used (#229).
 
 * `yml_ext()` has been removed because support for the `yml` file extension has 
   been removed (#211).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,48 @@
+# rbabylon (development version)
+
+## Breaking changes
+
+* `.base_dir` becomes a required argument to `config_log()`, `run_log()`, and 
+  `summary_log()` (#227).
+
+* The `.directory` argument is removed from `copy_model_from()`, 
+  `model_summaries()`, `model_summary()`, `new_model()`, and `read_model()` 
+  (#217, #222, #224, #226).
+
+* The `.yaml_path` argument to `new_model()` becomes `.path` to reflect that a
+  single path identifies the output directory and the model and YAML files 
+  (without extension). `new_model()` and `read_model()` throw an error if a 
+  model file is not found at `.path` (#217).
+  
+### Removed
+
+* `as_model()` has been removed because it was not used (#194).
+
+* The `character` and `numeric` methods for `copy_model_from()`, 
+  `model_summaries()`, `model_summary()`, `submit_model()`, and 
+  `submit_models()` have been removed because they created an unnecessarily 
+  complicated interface (#188).
+  
+* `get_path_from_object()` has been removed and replaced by equivalent 
+  functionality, e.g., `get_model_path()` (#195).
+
+* `get_model_directory()` and `set_model_directory()` have been removed because
+  the `rbabylon.model_directory` option is no longer used (#229).
+
+* `yml_ext()` has been removed because support for the `yml` file extension has 
+  been removed (#211).
+
+## New features
+
+* `get_model_path()`, `get_output_dir()`, `get_yaml_path()` return the paths to 
+  the model file, the output directory, and the model YAML file, respectively,
+  replacing `get_path_from_object()` (#195).
+
+* The object returned by each of `add_config()`, `add_summary()`, 
+  `config_log()`, `run_log()`, and `summary_log()` inherits from abstract class
+  `bbi_log_df`. `get_model_path()`, `get_output_dir()`, and `get_yaml_path()` 
+  gain methods for this new class (#192).
+
 # rbabylon 0.8.0
 
 * Added vignette demonstrating new `summary_log()` functionality.

--- a/R/copy-model-from.R
+++ b/R/copy-model-from.R
@@ -10,9 +10,9 @@
 #' vignette](../articles/using-based-on.html) for details.
 #' @param .parent_mod Model to copy from
 #' @param .new_model Path to the new model, either absolute or relative to the
-#'   path to `.parent_model`. Represents an absolute model path, which is the
-#'   path to the YAML file and model file, both without extension, and the
-#'   output directory (once the model is run). Numeric values will be coerced to
+#'   path to `.parent_mod`. Represents an absolute model path, which is the path
+#'   to the YAML file and model file, both without extension, and the output
+#'   directory (once the model is run). Numeric values will be coerced to
 #'   character. See examples for usage.
 #' @param .description Description of new model run. This will be stored in the
 #'   yaml (to be used later in `run_log()`).

--- a/man/build_new_model_path.Rd
+++ b/man/build_new_model_path.Rd
@@ -12,9 +12,9 @@ build_new_model_path(.parent_mod, .new_model)
 \item{.parent_mod}{Model to copy from}
 
 \item{.new_model}{Path to the new model, either absolute or relative to the
-path to \code{.parent_model}. Represents an absolute model path, which is the
-path to the YAML file and model file, both without extension, and the
-output directory (once the model is run). Numeric values will be coerced to
+path to \code{.parent_mod}. Represents an absolute model path, which is the path
+to the YAML file and model file, both without extension, and the output
+directory (once the model is run). Numeric values will be coerced to
 character. See examples for usage.}
 }
 \value{

--- a/man/copy_model_from.Rd
+++ b/man/copy_model_from.Rd
@@ -31,9 +31,9 @@ copy_model_from(
 \item{.parent_mod}{Model to copy from}
 
 \item{.new_model}{Path to the new model, either absolute or relative to the
-path to \code{.parent_model}. Represents an absolute model path, which is the
-path to the YAML file and model file, both without extension, and the
-output directory (once the model is run). Numeric values will be coerced to
+path to \code{.parent_mod}. Represents an absolute model path, which is the path
+to the YAML file and model file, both without extension, and the output
+directory (once the model is run). Numeric values will be coerced to
 character. See examples for usage.}
 
 \item{.description}{Description of new model run. This will be stored in the


### PR DESCRIPTION
This PR updates `NEWS.md` to reflect the user-facing changes for the `rbabylon.model_directory` refactor milestone. We probably want to include a more narrative description (versus bullet points) in the release notes.