### PR TITLE
Release/0.11.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rbabylon
 Title: R package for babylon
-Version: 0.10.0.7100
+Version: 0.11.0
 Authors@R: 
     c(person(given = "Devin",
              family = "Pastoor",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rbabylon
 Title: R package for babylon
-Version: 0.10.0.7006
+Version: 0.10.0.7100
 Authors@R: 
     c(person(given = "Devin",
              family = "Pastoor",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# rbabylon 0.11.0
+
+## New features and changes
+
+* Added print methods for `bbi_nonmem_summary` and `babylon_process` objects. The `bbi_nonmem_summary` object should print nicely in the console, and also look good in `.Rmd` chunks with the option `results = 'asis'`. (#298 and #294)
+
+* The `bbi_nonmem_summary` object now contains the `absolute_model_path` and we have added the following methods to work on that object (these previously only worked on `bbi_nonmem_model` objects): `get_model_id()`, `get_model_path()`, `get_output_dir()`, `get_yaml_path()`, `check_grd()`, `check_ext()`. (#297)
+
+* For developers, there are now scripts in `data-raw` which regenerate the test reference files and re-run the test models. All test references and example files have now been consolidated in `inst` as well. Users will see these files in `extdata`, `model`, and `test-refs` when the package is installed. (#289)
+
+## Bug fixes
+
+* Previously `replace_model_field()`, which is called under the hood by `replace_tag()` and `replace_note()` did _not_ modify the YAML file as it should have. That has been fixed. (#281)
+
+* Previously the `add_summary()` function would error if all the model summaries errored. Now it will return, passing through the model summary errors to the tibble, as it should. (#282)
+
 # rbabylon 0.10.0
 
 ## New features and changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * For developers, there are now scripts in `data-raw` which regenerate the test reference files and re-run the test models. All test references and example files have now been consolidated in `inst` as well. Users will see these files in `extdata`, `model`, and `test-refs` when the package is installed. (#289)
 
+* Also for developers, we are now using `pkgr` and `renv` to isolate dependencies when developing. The `README` has been updated with instructions for how to use this when developing. (#276)
+
 ## Bug fixes
 
 * Previously `replace_model_field()`, which is called under the hood by `replace_tag()` and `replace_note()` did _not_ modify the YAML file as it should have. That has been fixed. (#281)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -52,6 +52,7 @@ reference:
   - get_model_path
   - get_output_dir
   - get_yaml_path
+  - print_bbi
 - title: Babylon configuration
   contents:
   - bbi_current_release

--- a/docs/404.html
+++ b/docs/404.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="https://metrumresearchgroup.github.io/rbabylon/index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -84,7 +84,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -119,7 +119,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -84,7 +84,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -119,7 +119,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -84,7 +84,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -119,7 +119,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/articles/getting-started.html
+++ b/docs/articles/getting-started.html
@@ -38,7 +38,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -46,7 +46,7 @@
       <ul class="nav navbar-nav">
 <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -81,7 +81,7 @@
 <ul class="nav navbar-nav navbar-right">
 <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -114,8 +114,8 @@
 <a href="#introduction" class="anchor"></a>Introduction</h1>
 <p>This “Getting Started with rbabylon” vignette takes the user through some basic scenarios for modeling with NONMEM using <code>rbabylon</code>, introducing you to its standard workflow and functionality.</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(rbabylon)</a>
-<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/base/message.html">suppressPackageStartupMessages</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(dplyr))</a>
-<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="kw"><a href="https://rdrr.io/r/base/message.html">suppressPackageStartupMessages</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(purrr))</a></code></pre></div>
+<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(dplyr)</a>
+<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(purrr)</a></code></pre></div>
 <p><code>rbabylon</code> is an R interface for running <code>babylon</code>, which is (will be) a complete solution for managing projects involving modeling and simulation with a number of software solutions used in pharmaceutical sciences. Currently, only NONMEM is supported, so this vignette will only address that.</p>
 </div>
 <div id="setup" class="section level1">
@@ -149,7 +149,7 @@
 <h3 class="hasAnchor">
 <a href="#bbi_init" class="anchor"></a>bbi_init()</h3>
 <p>The <code><a href="../reference/bbi_init.html">bbi_init()</a></code> function will create a <code>babylon.yaml</code>, with the default settings, in the specified directory. Optionally, you can pass the path to a <code>babylon.yaml</code> to the <code>.config_path</code> argument of any <code>rbabylon</code> function that needs one. However, by default these functions will look for one in the same folder as the model being submitted or manipulated. Therefore, if you will have a number of models in the same folder, it is easiest to put a <code>babylon.yaml</code> that folder.</p>
-<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1">MODEL_DIR &lt;-<span class="st"> "../nonmem"</span>    <span class="co"># this should be relative to your working directory</span></a>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1">MODEL_DIR &lt;-<span class="st"> "../model/nonmem/basic"</span>  <span class="co"># this should be relative to your working directory</span></a>
 <a class="sourceLine" id="cb4-2" data-line-number="2"></a>
 <a class="sourceLine" id="cb4-3" data-line-number="3"><span class="kw"><a href="../reference/bbi_init.html">bbi_init</a></span>(<span class="dt">.dir =</span> MODEL_DIR,            <span class="co"># the directory to create the babylon.yaml in</span></a>
 <a class="sourceLine" id="cb4-4" data-line-number="4">         <span class="dt">.nonmem_dir =</span> <span class="st">"/opt/NONMEM"</span>, <span class="co"># location of NONMEM installation</span></a>
@@ -247,9 +247,9 @@
 <p>Once the model run has completed, users can get a summary object containing much of the commonly used diagnostic information in a named list.</p>
 <div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1">sum1 &lt;-<span class="st"> </span>mod1 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/model_summary.html">model_summary</a></span>()</a>
 <a class="sourceLine" id="cb9-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/base/print.html">print</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/names.html">names</a></span>(sum1))</a>
-<a class="sourceLine" id="cb9-3" data-line-number="3"><span class="co">#&gt; [1] "run_details"       "run_heuristics"    "parameters_data"  </span></a>
-<a class="sourceLine" id="cb9-4" data-line-number="4"><span class="co">#&gt; [4] "parameter_names"   "ofv"               "condition_number" </span></a>
-<a class="sourceLine" id="cb9-5" data-line-number="5"><span class="co">#&gt; [7] "shrinkage_details"</span></a></code></pre></div>
+<a class="sourceLine" id="cb9-3" data-line-number="3"><span class="co">#&gt; [1] "absolute_model_path" "run_details"         "run_heuristics"     </span></a>
+<a class="sourceLine" id="cb9-4" data-line-number="4"><span class="co">#&gt; [4] "parameters_data"     "parameter_names"     "ofv"                </span></a>
+<a class="sourceLine" id="cb9-5" data-line-number="5"><span class="co">#&gt; [7] "condition_number"    "shrinkage_details"</span></a></code></pre></div>
 <p>These elements can be accessed manually or extracted with built-in helper functions like so:</p>
 <div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb10-1" data-line-number="1">param_df1 &lt;-<span class="st"> </span>sum1 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/param_estimates.html">param_estimates</a></span>()</a>
 <a class="sourceLine" id="cb10-2" data-line-number="2">param_df1</a>
@@ -290,8 +290,9 @@
 <h2 class="hasAnchor">
 <a href="#adding-tags-and-notes" class="anchor"></a>Adding tags and notes</h2>
 <p>After looking at these results, the user can add tags, which can later be used to organize your modeling runs.</p>
-<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb14-1" data-line-number="1">mod1 &lt;-<span class="st"> </span>mod1 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/modify_tags.html">add_tags</a></span>(<span class="st">"base model"</span>)</a>
-<a class="sourceLine" id="cb14-2" data-line-number="2">mod2 &lt;-<span class="st"> </span>mod2 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/modify_tags.html">add_tags</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"base model"</span>, <span class="st">"2 compartment"</span>))</a></code></pre></div>
+<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb14-1" data-line-number="1">mod1 &lt;-<span class="st"> </span>mod1 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/modify_tags.html">add_tags</a></span>(<span class="st">"orig acop model"</span>)</a>
+<a class="sourceLine" id="cb14-2" data-line-number="2">mod2 &lt;-<span class="st"> </span>mod2 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/modify_tags.html">add_tags</a></span>(<span class="st">"2 compartment"</span>)</a></code></pre></div>
+<p>Note that using free text for your tags is discouraged, for reasons mentioned in the <code><a href="../reference/modify_tags.html">?modify_tags</a></code> help page. For simplicity’s sake, we ignore that advice here, but please read it before using tags extensively in the wild.</p>
 <p>In addition to tags, the user can add notes that can be referenced later.</p>
 <div class="sourceCode" id="cb15"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb15-1" data-line-number="1">mod2 &lt;-<span class="st"> </span>mod2 <span class="op">%&gt;%</span><span class="st"> </span></a>
 <a class="sourceLine" id="cb15-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="../reference/modify_notes.html">add_notes</a></span>(<span class="st">"2 compartment model more appropriate than 1 compartment"</span>)</a></code></pre></div>
@@ -299,16 +300,16 @@
 <div id="continue-to-iterate" class="section level2">
 <h2 class="hasAnchor">
 <a href="#continue-to-iterate" class="anchor"></a>Continue to iterate…</h2>
-<p>Now the iteration process continues with a third model.</p>
-<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb16-1" data-line-number="1">mod3 &lt;-<span class="st"> </span><span class="kw"><a href="../reference/copy_model_from.html">copy_model_from</a></span>(mod2, <span class="dv">3</span>)</a></code></pre></div>
+<p>Now the iteration process continues with a third model. Note that you can tell <code><a href="../reference/copy_model_from.html">copy_model_from()</a></code> to inherit the tags from the parent model and automatically add them to the new model.</p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb16-1" data-line-number="1">mod3 &lt;-<span class="st"> </span><span class="kw"><a href="../reference/copy_model_from.html">copy_model_from</a></span>(mod2, <span class="dv">3</span>, <span class="dt">.inherit_tags =</span> <span class="ot">TRUE</span>)</a></code></pre></div>
 <p>Submit and summarize as before.</p>
 <div class="sourceCode" id="cb17"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb17-1" data-line-number="1"><span class="co"># manually edit control stream, then...</span></a>
 <a class="sourceLine" id="cb17-2" data-line-number="2">mod3 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/submit_model.html">submit_model</a></span>()</a>
 <a class="sourceLine" id="cb17-3" data-line-number="3">mod3 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/model_summary.html">model_summary</a></span>()</a></code></pre></div>
 <p>Add tags and notes for filtering in run log, described next.</p>
 <div class="sourceCode" id="cb18"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb18-1" data-line-number="1">mod3 &lt;-<span class="st"> </span>mod3 <span class="op">%&gt;%</span><span class="st"> </span></a>
-<a class="sourceLine" id="cb18-2" data-line-number="2"><span class="st">        </span><span class="kw"><a href="../reference/modify_tags.html">add_tags</a></span>(<span class="st">"2 compartment"</span>) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb18-3" data-line-number="3"><span class="st">        </span><span class="kw"><a href="../reference/modify_notes.html">add_notes</a></span>(<span class="st">"Added residual errors because it seemed like a good idea."</span>)</a></code></pre></div>
+<a class="sourceLine" id="cb18-2" data-line-number="2"><span class="st">        </span><span class="kw"><a href="../reference/modify_tags.html">add_tags</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"combined RUV"</span>, <span class="st">"iiv CL"</span>)) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb18-3" data-line-number="3"><span class="st">        </span><span class="kw"><a href="../reference/modify_notes.html">add_notes</a></span>(<span class="st">"Added combined error structure because it seemed like a good idea"</span>)</a></code></pre></div>
 </div>
 </div>
 <div id="run-log" class="section level1">
@@ -321,9 +322,9 @@
 <a class="sourceLine" id="cb19-3" data-line-number="3"><span class="co">#&gt; # A tibble: 3 x 10</span></a>
 <a class="sourceLine" id="cb19-4" data-line-number="4"><span class="co">#&gt;   absolute_model_… run   yaml_md5 model_type description bbi_args based_on tags </span></a>
 <a class="sourceLine" id="cb19-5" data-line-number="5"><span class="co">#&gt;   &lt;chr&gt;            &lt;chr&gt; &lt;chr&gt;    &lt;chr&gt;      &lt;chr&gt;       &lt;list&gt;   &lt;list&gt;   &lt;lis&gt;</span></a>
-<a class="sourceLine" id="cb19-6" data-line-number="6"><span class="co">#&gt; 1 /tmp/RtmpZUCZ4V… 1     7850aa9… nonmem     &lt;NA&gt;        &lt;list [… &lt;NULL&gt;   &lt;chr…</span></a>
-<a class="sourceLine" id="cb19-7" data-line-number="7"><span class="co">#&gt; 2 /tmp/RtmpZUCZ4V… 2     8175338… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;chr…</span></a>
-<a class="sourceLine" id="cb19-8" data-line-number="8"><span class="co">#&gt; 3 /tmp/RtmpZUCZ4V… 3     a304c5f… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;chr…</span></a>
+<a class="sourceLine" id="cb19-6" data-line-number="6"><span class="co">#&gt; 1 /tmp/Rtmpxo18BY… 1     c7486e7… nonmem     &lt;NA&gt;        &lt;list [… &lt;NULL&gt;   &lt;chr…</span></a>
+<a class="sourceLine" id="cb19-7" data-line-number="7"><span class="co">#&gt; 2 /tmp/Rtmpxo18BY… 2     bc60c6b… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;chr…</span></a>
+<a class="sourceLine" id="cb19-8" data-line-number="8"><span class="co">#&gt; 3 /tmp/Rtmpxo18BY… 3     cfceb67… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;chr…</span></a>
 <a class="sourceLine" id="cb19-9" data-line-number="9"><span class="co">#&gt; # … with 2 more variables: notes &lt;list&gt;, decisions &lt;list&gt;</span></a></code></pre></div>
 <p>The <code><a href="../reference/run_log.html">run_log()</a></code> returns a tibble which can be manipulated like any other tibble. However, several of the columns (<code>tags</code>, <code>notes</code>, and <code>based_on</code> for example) are list columns, which complicates how you can interact with them. We provide some helper functions to more seamlessly interact with these log tibbles, as well as some sample <code>tidyverse</code> code below.</p>
 <div id="viewing-tags-example" class="section level2">
@@ -334,11 +335,11 @@
 <a class="sourceLine" id="cb20-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="../reference/collapse_to_string.html">collapse_to_string</a></span>(tags, notes) <span class="op">%&gt;%</span></a>
 <a class="sourceLine" id="cb20-3" data-line-number="3"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(run, tags, notes)</a>
 <a class="sourceLine" id="cb20-4" data-line-number="4"><span class="co">#&gt; # A tibble: 3 x 3</span></a>
-<a class="sourceLine" id="cb20-5" data-line-number="5"><span class="co">#&gt;   run   tags                   notes                                            </span></a>
-<a class="sourceLine" id="cb20-6" data-line-number="6"><span class="co">#&gt;   &lt;chr&gt; &lt;chr&gt;                  &lt;chr&gt;                                            </span></a>
-<a class="sourceLine" id="cb20-7" data-line-number="7"><span class="co">#&gt; 1 1     base model             &lt;NA&gt;                                             </span></a>
-<a class="sourceLine" id="cb20-8" data-line-number="8"><span class="co">#&gt; 2 2     base model, 2 compart… 2 compartment model more appropriate than 1 comp…</span></a>
-<a class="sourceLine" id="cb20-9" data-line-number="9"><span class="co">#&gt; 3 3     2 compartment          Added residual errors because it seemed like a g…</span></a></code></pre></div>
+<a class="sourceLine" id="cb20-5" data-line-number="5"><span class="co">#&gt;   run   tags                       notes                                        </span></a>
+<a class="sourceLine" id="cb20-6" data-line-number="6"><span class="co">#&gt;   &lt;chr&gt; &lt;chr&gt;                      &lt;chr&gt;                                        </span></a>
+<a class="sourceLine" id="cb20-7" data-line-number="7"><span class="co">#&gt; 1 1     orig acop model            &lt;NA&gt;                                         </span></a>
+<a class="sourceLine" id="cb20-8" data-line-number="8"><span class="co">#&gt; 2 2     2 compartment              2 compartment model more appropriate than 1 …</span></a>
+<a class="sourceLine" id="cb20-9" data-line-number="9"><span class="co">#&gt; 3 3     2 compartment, combined R… Added combined error structure because it se…</span></a></code></pre></div>
 </div>
 <div id="filtering-tags-example" class="section level2">
 <h2 class="hasAnchor">
@@ -346,12 +347,13 @@
 <p>This code uses <code><a href="https://purrr.tidyverse.org/reference/map.html">purrr::map_lgl</a></code> to filter the run log to only rows containing a specific tag (<code>"2 compartment"</code>).</p>
 <div class="sourceCode" id="cb21"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb21-1" data-line-number="1">log_df <span class="op">%&gt;%</span><span class="st"> </span></a>
 <a class="sourceLine" id="cb21-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="kw"><a href="https://purrr.tidyverse.org/reference/map.html">map_lgl</a></span>(tags, <span class="op">~</span><span class="st"> "2 compartment"</span> <span class="op">%in%</span><span class="st"> </span>.x)) <span class="op">%&gt;%</span></a>
-<a class="sourceLine" id="cb21-3" data-line-number="3"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(run, tags, notes)</a>
-<a class="sourceLine" id="cb21-4" data-line-number="4"><span class="co">#&gt; # A tibble: 2 x 3</span></a>
-<a class="sourceLine" id="cb21-5" data-line-number="5"><span class="co">#&gt;   run   tags      notes    </span></a>
-<a class="sourceLine" id="cb21-6" data-line-number="6"><span class="co">#&gt;   &lt;chr&gt; &lt;list&gt;    &lt;list&gt;   </span></a>
-<a class="sourceLine" id="cb21-7" data-line-number="7"><span class="co">#&gt; 1 2     &lt;chr [2]&gt; &lt;chr [1]&gt;</span></a>
-<a class="sourceLine" id="cb21-8" data-line-number="8"><span class="co">#&gt; 2 3     &lt;chr [1]&gt; &lt;chr [1]&gt;</span></a></code></pre></div>
+<a class="sourceLine" id="cb21-3" data-line-number="3"><span class="st">  </span><span class="kw"><a href="../reference/collapse_to_string.html">collapse_to_string</a></span>(tags, notes) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb21-4" data-line-number="4"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(run, tags, notes)</a>
+<a class="sourceLine" id="cb21-5" data-line-number="5"><span class="co">#&gt; # A tibble: 2 x 3</span></a>
+<a class="sourceLine" id="cb21-6" data-line-number="6"><span class="co">#&gt;   run   tags                       notes                                        </span></a>
+<a class="sourceLine" id="cb21-7" data-line-number="7"><span class="co">#&gt;   &lt;chr&gt; &lt;chr&gt;                      &lt;chr&gt;                                        </span></a>
+<a class="sourceLine" id="cb21-8" data-line-number="8"><span class="co">#&gt; 1 2     2 compartment              2 compartment model more appropriate than 1 …</span></a>
+<a class="sourceLine" id="cb21-9" data-line-number="9"><span class="co">#&gt; 2 3     2 compartment, combined R… Added combined error structure because it se…</span></a></code></pre></div>
 </div>
 </div>
 <div id="further-reading" class="section level1">

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -84,7 +84,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -119,7 +119,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/articles/parameter-labels.html
+++ b/docs/articles/parameter-labels.html
@@ -38,7 +38,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -46,7 +46,7 @@
       <ul class="nav navbar-nav">
 <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -81,7 +81,7 @@
 <ul class="nav navbar-nav navbar-right">
 <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -119,8 +119,8 @@
 <a href="#setup" class="anchor"></a>Setup</h2>
 <p>There is some initial set up necessary for using <code>rbabylon</code>. Please refer to the <a href="https://metrumresearchgroup.github.io/rbabylon/articles/getting-started.html#setup">“Getting Started”</a> vignette, mentioned above, if you have not done this yet. Once this is done, load the library.</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(rbabylon)</a>
-<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/base/message.html">suppressPackageStartupMessages</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(dplyr))</a>
-<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="kw"><a href="https://rdrr.io/r/base/message.html">suppressPackageStartupMessages</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(readr))</a></code></pre></div>
+<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(dplyr)</a>
+<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(readr)</a></code></pre></div>
 </div>
 </div>
 <div id="parameter-labels" class="section level1">
@@ -130,7 +130,7 @@
 <h2 class="hasAnchor">
 <a href="#create-model-object" class="anchor"></a>Create Model Object</h2>
 <p>We have a control stream and output directory, because the model has already been run.</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1">MODEL_DIR &lt;-<span class="st"> </span><span class="kw"><a href="https://rdrr.io/r/base/system.file.html">system.file</a></span>(<span class="st">"param_examples"</span>, <span class="dt">package =</span> <span class="st">"rbabylon"</span>)</a>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1">MODEL_DIR &lt;-<span class="st"> </span><span class="kw"><a href="https://rdrr.io/r/base/system.file.html">system.file</a></span>(<span class="st">"test-refs"</span>, <span class="st">"param-labels"</span>, <span class="st">"example-model"</span>, <span class="dt">package =</span> <span class="st">"rbabylon"</span>)</a>
 <a class="sourceLine" id="cb2-2" data-line-number="2"></a>
 <a class="sourceLine" id="cb2-3" data-line-number="3">mod1 &lt;-<span class="st"> </span><span class="kw"><a href="../reference/read_model.html">read_model</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/file.path.html">file.path</a></span>(MODEL_DIR, <span class="st">"510"</span>))</a>
 <a class="sourceLine" id="cb2-4" data-line-number="4"><span class="kw"><a href="https://rdrr.io/r/base/class.html">class</a></span>(mod1)</a>
@@ -206,7 +206,7 @@
 <a class="sourceLine" id="cb5-17" data-line-number="17"><span class="co">#&gt; 10 SIGMA(1,1)       0.0450  0.00388           0.212           0.00914 FALSE</span></a>
 <a class="sourceLine" id="cb5-18" data-line-number="18"><span class="co">#&gt; # … with 2 more variables: diag &lt;lgl&gt;, shrinkage &lt;dbl&gt;</span></a></code></pre></div>
 <p>These two tibbles can be joined together to create a table for including in reports.</p>
-<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">report_df &lt;-<span class="st"> </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/join.html">inner_join</a></span>(</a>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">report_df &lt;-<span class="st"> </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/mutate-joins.html">inner_join</a></span>(</a>
 <a class="sourceLine" id="cb6-2" data-line-number="2">  label_df <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(<span class="op">-</span>param_type),</a>
 <a class="sourceLine" id="cb6-3" data-line-number="3">  param_df <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(parameter_names, estimate, stderr),</a>
 <a class="sourceLine" id="cb6-4" data-line-number="4">  <span class="dt">by =</span> <span class="st">"parameter_names"</span></a>

--- a/docs/articles/using-based-on.html
+++ b/docs/articles/using-based-on.html
@@ -38,7 +38,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -46,7 +46,7 @@
       <ul class="nav navbar-nav">
 <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -81,7 +81,7 @@
 <ul class="nav navbar-nav navbar-right">
 <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -119,9 +119,8 @@
 <a href="#setup" class="anchor"></a>Setup</h2>
 <p>There is some initial set up necessary for using <code>rbabylon</code>. Please refer to the <a href="https://metrumresearchgroup.github.io/rbabylon/articles/getting-started.html#setup">“Getting Started”</a> vignette, mentioned above, if you have not done this yet. Once this is done, load the library.</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(rbabylon)</a>
-<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/base/message.html">suppressPackageStartupMessages</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(dplyr))</a>
-<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="kw"><a href="https://rdrr.io/r/base/message.html">suppressPackageStartupMessages</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(purrr))</a>
-<a class="sourceLine" id="cb1-4" data-line-number="4"><span class="kw"><a href="https://rdrr.io/r/base/message.html">suppressPackageStartupMessages</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(fs))</a></code></pre></div>
+<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(dplyr)</a>
+<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(purrr)</a></code></pre></div>
 </div>
 </div>
 <div id="modeling-process" class="section level1">
@@ -153,8 +152,8 @@
 <a class="sourceLine" id="cb5-15" data-line-number="15">mod6 &lt;-<span class="st"> </span><span class="kw"><a href="../reference/copy_model_from.html">copy_model_from</a></span>(mod5, <span class="dv">6</span>)</a>
 <a class="sourceLine" id="cb5-16" data-line-number="16"></a>
 <a class="sourceLine" id="cb5-17" data-line-number="17"><span class="co"># ...submit mod6...look at diagnostics...decide you're done!</span></a></code></pre></div>
-<p>Now that you have arrived at your final model, you can add a tag to it, which will be used shortly for filtering the <code><a href="../reference/run_log.html">run_log()</a></code> tibble.</p>
-<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">mod6 &lt;-<span class="st"> </span>mod6 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/modify_tags.html">add_tags</a></span>(<span class="st">"final model"</span>)</a></code></pre></div>
+<p>Now that you have arrived at your final model, you can add a description to identify it, which will be used shortly for filtering the <code><a href="../reference/run_log.html">run_log()</a></code> tibble.</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">mod6 &lt;-<span class="st"> </span>mod6 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/modify_description.html">add_description</a></span>(<span class="st">"Final model"</span>)</a></code></pre></div>
 </div>
 <div id="operating-on-a-model-object" class="section level1">
 <h1 class="hasAnchor">
@@ -165,14 +164,14 @@
 <a href="#get_based_on" class="anchor"></a>get_based_on</h2>
 <p>First, by using <code><a href="../reference/get_based_on.html">get_based_on()</a></code> you can retrieve the absolute path to all models in the <code>based_on</code> field.</p>
 <div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" data-line-number="1">mod6 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/get_based_on.html">get_based_on</a></span>()</a>
-<a class="sourceLine" id="cb7-2" data-line-number="2"><span class="co">#&gt; [1] "/tmp/RtmpZUCZ4V/temp_libpath676f6ebc1916/rbabylon/nonmem/5"</span></a></code></pre></div>
+<a class="sourceLine" id="cb7-2" data-line-number="2"><span class="co">#&gt; [1] "/tmp/Rtmpxo18BY/temp_libpath117b4e35470c/rbabylon/model/nonmem/basic/5"</span></a></code></pre></div>
 <p>This is useful because the path(s) retrieved will unambiguously identify the parent model(s) and can therefore be passed to things like <code><a href="../reference/read_model.html">read_model()</a></code> or <code><a href="../reference/model_summary.html">model_summary()</a></code> like so:</p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb8-1" data-line-number="1">parent_mod &lt;-<span class="st"> </span>mod6 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/get_based_on.html">get_based_on</a></span>() <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/read_model.html">read_model</a></span>()</a>
 <a class="sourceLine" id="cb8-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/utils/str.html">str</a></span>(parent_mod)</a>
 <a class="sourceLine" id="cb8-3" data-line-number="3"><span class="co">#&gt; List of 5</span></a>
 <a class="sourceLine" id="cb8-4" data-line-number="4"><span class="co">#&gt;  $ model_type         : chr "nonmem"</span></a>
 <a class="sourceLine" id="cb8-5" data-line-number="5"><span class="co">#&gt;  $ based_on           : chr "2"</span></a>
-<a class="sourceLine" id="cb8-6" data-line-number="6"><span class="co">#&gt;  $ absolute_model_path: chr "/tmp/RtmpZUCZ4V/temp_libpath676f6ebc1916/rbabylon/nonmem/5"</span></a>
+<a class="sourceLine" id="cb8-6" data-line-number="6"><span class="co">#&gt;  $ absolute_model_path: chr "/tmp/Rtmpxo18BY/temp_libpath117b4e35470c/rbabylon/model/nonmem/basic/5"</span></a>
 <a class="sourceLine" id="cb8-7" data-line-number="7"><span class="co">#&gt;  $ yaml_md5           : chr "ac0ba292b017a72bb316359f0df09bb2"</span></a>
 <a class="sourceLine" id="cb8-8" data-line-number="8"><span class="co">#&gt;  $ bbi_args           : list()</span></a>
 <a class="sourceLine" id="cb8-9" data-line-number="9"><span class="co">#&gt;  - attr(*, "class")= chr [1:2] "bbi_nonmem_model" "list"</span></a></code></pre></div>
@@ -182,9 +181,9 @@
 <a href="#get_model_ancestry" class="anchor"></a>get_model_ancestry</h2>
 <p>The second helper function walks up the tree of inheritence by iteratively calling <code><a href="../reference/get_based_on.html">get_based_on()</a></code> on each parent model to determine the full set of models that led up to the current model.</p>
 <div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1">mod6 <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="../reference/get_based_on.html">get_model_ancestry</a></span>()</a>
-<a class="sourceLine" id="cb9-2" data-line-number="2"><span class="co">#&gt; [1] "/tmp/RtmpZUCZ4V/temp_libpath676f6ebc1916/rbabylon/nonmem/1"</span></a>
-<a class="sourceLine" id="cb9-3" data-line-number="3"><span class="co">#&gt; [2] "/tmp/RtmpZUCZ4V/temp_libpath676f6ebc1916/rbabylon/nonmem/2"</span></a>
-<a class="sourceLine" id="cb9-4" data-line-number="4"><span class="co">#&gt; [3] "/tmp/RtmpZUCZ4V/temp_libpath676f6ebc1916/rbabylon/nonmem/5"</span></a></code></pre></div>
+<a class="sourceLine" id="cb9-2" data-line-number="2"><span class="co">#&gt; [1] "/tmp/Rtmpxo18BY/temp_libpath117b4e35470c/rbabylon/model/nonmem/basic/1"</span></a>
+<a class="sourceLine" id="cb9-3" data-line-number="3"><span class="co">#&gt; [2] "/tmp/Rtmpxo18BY/temp_libpath117b4e35470c/rbabylon/model/nonmem/basic/2"</span></a>
+<a class="sourceLine" id="cb9-4" data-line-number="4"><span class="co">#&gt; [3] "/tmp/Rtmpxo18BY/temp_libpath117b4e35470c/rbabylon/model/nonmem/basic/5"</span></a></code></pre></div>
 <p>In this case, model <code>6</code> was based on <code>5</code>, which was based on <code>2</code>, which in turn was based on <code>1</code>. You will see one example of how this can be useful in the “Final model family” section below.</p>
 </div>
 </div>
@@ -197,36 +196,33 @@
 <a class="sourceLine" id="cb10-3" data-line-number="3"><span class="co">#&gt; # A tibble: 6 x 10</span></a>
 <a class="sourceLine" id="cb10-4" data-line-number="4"><span class="co">#&gt;   absolute_model_… run   yaml_md5 model_type description bbi_args based_on tags </span></a>
 <a class="sourceLine" id="cb10-5" data-line-number="5"><span class="co">#&gt;   &lt;chr&gt;            &lt;chr&gt; &lt;chr&gt;    &lt;chr&gt;      &lt;chr&gt;       &lt;list&gt;   &lt;list&gt;   &lt;lis&gt;</span></a>
-<a class="sourceLine" id="cb10-6" data-line-number="6"><span class="co">#&gt; 1 /tmp/RtmpZUCZ4V… 1     3e3e686… nonmem     &lt;NA&gt;        &lt;list [… &lt;NULL&gt;   &lt;NUL…</span></a>
-<a class="sourceLine" id="cb10-7" data-line-number="7"><span class="co">#&gt; 2 /tmp/RtmpZUCZ4V… 2     b992cc4… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;NUL…</span></a>
-<a class="sourceLine" id="cb10-8" data-line-number="8"><span class="co">#&gt; 3 /tmp/RtmpZUCZ4V… 3     ac0ba29… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;NUL…</span></a>
-<a class="sourceLine" id="cb10-9" data-line-number="9"><span class="co">#&gt; 4 /tmp/RtmpZUCZ4V… 4     6818db1… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;NUL…</span></a>
-<a class="sourceLine" id="cb10-10" data-line-number="10"><span class="co">#&gt; 5 /tmp/RtmpZUCZ4V… 5     ac0ba29… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;NUL…</span></a>
-<a class="sourceLine" id="cb10-11" data-line-number="11"><span class="co">#&gt; 6 /tmp/RtmpZUCZ4V… 6     54f4e98… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;chr…</span></a>
+<a class="sourceLine" id="cb10-6" data-line-number="6"><span class="co">#&gt; 1 /tmp/Rtmpxo18BY… 1     3e3e686… nonmem     &lt;NA&gt;        &lt;list [… &lt;NULL&gt;   &lt;NUL…</span></a>
+<a class="sourceLine" id="cb10-7" data-line-number="7"><span class="co">#&gt; 2 /tmp/Rtmpxo18BY… 2     b992cc4… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;NUL…</span></a>
+<a class="sourceLine" id="cb10-8" data-line-number="8"><span class="co">#&gt; 3 /tmp/Rtmpxo18BY… 3     ac0ba29… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;NUL…</span></a>
+<a class="sourceLine" id="cb10-9" data-line-number="9"><span class="co">#&gt; 4 /tmp/Rtmpxo18BY… 4     6818db1… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;NUL…</span></a>
+<a class="sourceLine" id="cb10-10" data-line-number="10"><span class="co">#&gt; 5 /tmp/Rtmpxo18BY… 5     ac0ba29… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;NUL…</span></a>
+<a class="sourceLine" id="cb10-11" data-line-number="11"><span class="co">#&gt; 6 /tmp/Rtmpxo18BY… 6     feb9bf3… nonmem     Final model &lt;list [… &lt;chr [1… &lt;NUL…</span></a>
 <a class="sourceLine" id="cb10-12" data-line-number="12"><span class="co">#&gt; # … with 2 more variables: notes &lt;list&gt;, decisions &lt;list&gt;</span></a></code></pre></div>
-<div id="filtering-tags-example" class="section level2">
-<h2 class="hasAnchor">
-<a href="#filtering-tags-example" class="anchor"></a>Filtering tags example</h2>
-<p>Among other things, the run log contains the tags that have been assigned to each model. Here we use <code><a href="https://purrr.tidyverse.org/reference/map.html">purrr::map_lgl</a></code> to filter the run log to only the final model.</p>
+<p>Among other things, the run log contains any descriptions that have been assigned to each model. Here we use <code><a href="https://dplyr.tidyverse.org/reference/filter.html">dplyr::filter()</a></code> and <code><a href="https://dplyr.tidyverse.org/reference/pull.html">dplyr::pull()</a></code> to get the path to the final model.</p>
 <div class="sourceCode" id="cb11"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb11-1" data-line-number="1">final_model_path &lt;-<span class="st"> </span></a>
 <a class="sourceLine" id="cb11-2" data-line-number="2"><span class="st">  </span>log_df <span class="op">%&gt;%</span><span class="st"> </span></a>
-<a class="sourceLine" id="cb11-3" data-line-number="3"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="kw"><a href="https://purrr.tidyverse.org/reference/map.html">map_lgl</a></span>(tags, <span class="op">~</span><span class="st"> "final model"</span> <span class="op">%in%</span><span class="st"> </span>.x)) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb11-3" data-line-number="3"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(description <span class="op">==</span><span class="st"> "Final model"</span>) <span class="op">%&gt;%</span></a>
 <a class="sourceLine" id="cb11-4" data-line-number="4"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/pull.html">pull</a></span>(absolute_model_path)</a>
 <a class="sourceLine" id="cb11-5" data-line-number="5"></a>
 <a class="sourceLine" id="cb11-6" data-line-number="6">final_model_path</a>
-<a class="sourceLine" id="cb11-7" data-line-number="7"><span class="co">#&gt; [1] "/tmp/RtmpZUCZ4V/temp_libpath676f6ebc1916/rbabylon/nonmem/6"</span></a></code></pre></div>
+<a class="sourceLine" id="cb11-7" data-line-number="7"><span class="co">#&gt; [1] "/tmp/Rtmpxo18BY/temp_libpath117b4e35470c/rbabylon/model/nonmem/basic/6"</span></a></code></pre></div>
 <p>Next we can use the <code><a href="../reference/get_based_on.html">get_model_ancestry()</a></code> function to filter the tibble to only the models that led up to the final model.</p>
 <div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb12-1" data-line-number="1">log_df <span class="op">%&gt;%</span><span class="st"> </span></a>
-<a class="sourceLine" id="cb12-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(absolute_model_path <span class="op">%in%</span><span class="st"> </span><span class="kw"><a href="../reference/get_based_on.html">get_model_ancestry</a></span>(final_model_path))</a>
-<a class="sourceLine" id="cb12-3" data-line-number="3"><span class="co">#&gt; # A tibble: 3 x 10</span></a>
-<a class="sourceLine" id="cb12-4" data-line-number="4"><span class="co">#&gt;   absolute_model_… run   yaml_md5 model_type description bbi_args based_on tags </span></a>
-<a class="sourceLine" id="cb12-5" data-line-number="5"><span class="co">#&gt;   &lt;chr&gt;            &lt;chr&gt; &lt;chr&gt;    &lt;chr&gt;      &lt;chr&gt;       &lt;list&gt;   &lt;list&gt;   &lt;lis&gt;</span></a>
-<a class="sourceLine" id="cb12-6" data-line-number="6"><span class="co">#&gt; 1 /tmp/RtmpZUCZ4V… 1     3e3e686… nonmem     &lt;NA&gt;        &lt;list [… &lt;NULL&gt;   &lt;NUL…</span></a>
-<a class="sourceLine" id="cb12-7" data-line-number="7"><span class="co">#&gt; 2 /tmp/RtmpZUCZ4V… 2     b992cc4… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;NUL…</span></a>
-<a class="sourceLine" id="cb12-8" data-line-number="8"><span class="co">#&gt; 3 /tmp/RtmpZUCZ4V… 5     ac0ba29… nonmem     &lt;NA&gt;        &lt;list [… &lt;chr [1… &lt;NUL…</span></a>
-<a class="sourceLine" id="cb12-9" data-line-number="9"><span class="co">#&gt; # … with 2 more variables: notes &lt;list&gt;, decisions &lt;list&gt;</span></a></code></pre></div>
+<a class="sourceLine" id="cb12-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(absolute_model_path <span class="op">%in%</span><span class="st"> </span><span class="kw"><a href="../reference/get_based_on.html">get_model_ancestry</a></span>(final_model_path)) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb12-3" data-line-number="3"><span class="st">  </span><span class="kw"><a href="../reference/collapse_to_string.html">collapse_to_string</a></span>(based_on) <span class="op">%&gt;%</span><span class="st"> </span><span class="co"># collapses list column for easier printing</span></a>
+<a class="sourceLine" id="cb12-4" data-line-number="4"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(run, based_on)</a>
+<a class="sourceLine" id="cb12-5" data-line-number="5"><span class="co">#&gt; # A tibble: 3 x 2</span></a>
+<a class="sourceLine" id="cb12-6" data-line-number="6"><span class="co">#&gt;   run   based_on</span></a>
+<a class="sourceLine" id="cb12-7" data-line-number="7"><span class="co">#&gt;   &lt;chr&gt; &lt;chr&gt;   </span></a>
+<a class="sourceLine" id="cb12-8" data-line-number="8"><span class="co">#&gt; 1 1     &lt;NA&gt;    </span></a>
+<a class="sourceLine" id="cb12-9" data-line-number="9"><span class="co">#&gt; 2 2     1       </span></a>
+<a class="sourceLine" id="cb12-10" data-line-number="10"><span class="co">#&gt; 3 5     2</span></a></code></pre></div>
 <p>As you can see, models 3 and 4 are discarded because they did not lead to the final model. Review “Modeling Process” section above if you are not sure why this is the case. We will use the two techniques together in the “Final model family” section below.</p>
-</div>
 <div id="checking-if-models-are-up-to-date-with-config_log" class="section level2">
 <h2 class="hasAnchor">
 <a href="#checking-if-models-are-up-to-date-with-config_log" class="anchor"></a>Checking if models are up-to-date with config_log()</h2>
@@ -249,21 +245,24 @@
 <div id="final-model-family" class="section level2">
 <h2 class="hasAnchor">
 <a href="#final-model-family" class="anchor"></a>Final model family</h2>
-<p>From the <code>model_has_changed</code> column in the previous example, you can see that some of the model files have changed since they were run. However, you may only care about your final model and the models that led to it. You can use the <code>tags</code> and <code>based_on</code> columns from the <code><a href="../reference/run_log.html">run_log()</a></code> to filter to only those models.</p>
+<p>From the <code>model_has_changed</code> column in the previous example, you can see that some of the model files have changed since they were run. However, you may only care about your final model and the models that led to it. You can use the <code>description</code> and <code>based_on</code> columns from the <code><a href="../reference/run_log.html">run_log()</a></code> to filter to only those models.</p>
 <div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb14-1" data-line-number="1">final_model_family &lt;-<span class="st"> </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/bind.html">bind_rows</a></span>(</a>
 <a class="sourceLine" id="cb14-2" data-line-number="2">  log_df <span class="op">%&gt;%</span><span class="st"> </span></a>
 <a class="sourceLine" id="cb14-3" data-line-number="3"><span class="st">    </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(absolute_model_path <span class="op">%in%</span><span class="st"> </span><span class="kw"><a href="../reference/get_based_on.html">get_model_ancestry</a></span>(final_model_path)), <span class="co"># the ancestors of the final model</span></a>
 <a class="sourceLine" id="cb14-4" data-line-number="4">  log_df <span class="op">%&gt;%</span><span class="st"> </span></a>
-<a class="sourceLine" id="cb14-5" data-line-number="5"><span class="st">    </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(<span class="kw"><a href="https://purrr.tidyverse.org/reference/map.html">map_lgl</a></span>(tags, <span class="op">~</span><span class="st"> "final model"</span> <span class="op">%in%</span><span class="st"> </span>.x)) <span class="co"># the final model itself</span></a>
+<a class="sourceLine" id="cb14-5" data-line-number="5"><span class="st">    </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/filter.html">filter</a></span>(description <span class="op">==</span><span class="st"> "Final model"</span>) <span class="co"># the final model itself</span></a>
 <a class="sourceLine" id="cb14-6" data-line-number="6">)</a>
-<a class="sourceLine" id="cb14-7" data-line-number="7">final_model_family <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(run, model_has_changed, data_has_changed)</a>
-<a class="sourceLine" id="cb14-8" data-line-number="8"><span class="co">#&gt; # A tibble: 4 x 3</span></a>
-<a class="sourceLine" id="cb14-9" data-line-number="9"><span class="co">#&gt;   run   model_has_changed data_has_changed</span></a>
-<a class="sourceLine" id="cb14-10" data-line-number="10"><span class="co">#&gt;   &lt;chr&gt; &lt;lgl&gt;             &lt;lgl&gt;           </span></a>
-<a class="sourceLine" id="cb14-11" data-line-number="11"><span class="co">#&gt; 1 1     FALSE             FALSE           </span></a>
-<a class="sourceLine" id="cb14-12" data-line-number="12"><span class="co">#&gt; 2 2     FALSE             FALSE           </span></a>
-<a class="sourceLine" id="cb14-13" data-line-number="13"><span class="co">#&gt; 3 5     FALSE             FALSE           </span></a>
-<a class="sourceLine" id="cb14-14" data-line-number="14"><span class="co">#&gt; 4 6     FALSE             FALSE</span></a></code></pre></div>
+<a class="sourceLine" id="cb14-7" data-line-number="7"></a>
+<a class="sourceLine" id="cb14-8" data-line-number="8">final_model_family <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb14-9" data-line-number="9"><span class="st">  </span><span class="kw"><a href="../reference/collapse_to_string.html">collapse_to_string</a></span>(based_on) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb14-10" data-line-number="10"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(run, based_on, description, model_has_changed, data_has_changed)</a>
+<a class="sourceLine" id="cb14-11" data-line-number="11"><span class="co">#&gt; # A tibble: 4 x 5</span></a>
+<a class="sourceLine" id="cb14-12" data-line-number="12"><span class="co">#&gt;   run   based_on description model_has_changed data_has_changed</span></a>
+<a class="sourceLine" id="cb14-13" data-line-number="13"><span class="co">#&gt;   &lt;chr&gt; &lt;chr&gt;    &lt;chr&gt;       &lt;lgl&gt;             &lt;lgl&gt;           </span></a>
+<a class="sourceLine" id="cb14-14" data-line-number="14"><span class="co">#&gt; 1 1     &lt;NA&gt;     &lt;NA&gt;        FALSE             FALSE           </span></a>
+<a class="sourceLine" id="cb14-15" data-line-number="15"><span class="co">#&gt; 2 2     1        &lt;NA&gt;        FALSE             FALSE           </span></a>
+<a class="sourceLine" id="cb14-16" data-line-number="16"><span class="co">#&gt; 3 5     2        &lt;NA&gt;        FALSE             FALSE           </span></a>
+<a class="sourceLine" id="cb14-17" data-line-number="17"><span class="co">#&gt; 4 6     5        Final model FALSE             FALSE</span></a></code></pre></div>
 <p>When we filter to only those models, you can see that they are all still up-to-date. Great news.</p>
 </div>
 </div>
@@ -289,8 +288,7 @@
 </li>
       <li>
 <a href="#using-the-run-log">Using the run log</a><ul class="nav nav-pills nav-stacked">
-<li><a href="#filtering-tags-example">Filtering tags example</a></li>
-      <li><a href="#checking-if-models-are-up-to-date-with-config_log">Checking if models are up-to-date with config_log()</a></li>
+<li><a href="#checking-if-models-are-up-to-date-with-config_log">Checking if models are up-to-date with config_log()</a></li>
       <li><a href="#final-model-family">Final model family</a></li>
       </ul>
 </li>

--- a/docs/articles/using-summary-log.html
+++ b/docs/articles/using-summary-log.html
@@ -38,7 +38,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -46,7 +46,7 @@
       <ul class="nav navbar-nav">
 <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -81,7 +81,7 @@
 <ul class="nav navbar-nav navbar-right">
 <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -121,24 +121,24 @@
 <a href="#setup" class="anchor"></a>Setup</h2>
 <p>There is some initial set up necessary for using <code>rbabylon</code>. Please refer to the <a href="https://metrumresearchgroup.github.io/rbabylon/articles/getting-started.html#setup">“Getting Started”</a> vignette, mentioned above, if you have not done this yet. Once this is done, load the library.</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(rbabylon)</a>
-<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/base/message.html">suppressPackageStartupMessages</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(dplyr))</a>
-<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="kw"><a href="https://rdrr.io/r/base/message.html">suppressPackageStartupMessages</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(tidyselect))</a></code></pre></div>
+<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(dplyr)</a>
+<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(tidyselect)</a></code></pre></div>
 </div>
 </div>
 <div id="whats-in-a-model-summary" class="section level1">
 <h1 class="hasAnchor">
 <a href="#whats-in-a-model-summary" class="anchor"></a>What’s in a Model Summary?</h1>
 <p>As mentioned above, the <code>bbi_summary_log_df</code> tibble contains a lot of information, which is a subset of what is contained in the <code>bbi_nonmem_summary</code> object returned from <code><a href="../reference/model_summary.html">model_summary()</a></code>.</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1">MODEL_DIR &lt;-<span class="st"> "../tests/testthat/model-examples-complex"</span></a>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1">MODEL_DIR &lt;-<span class="st"> </span><span class="kw"><a href="https://rdrr.io/r/base/system.file.html">system.file</a></span>(<span class="st">"model"</span>, <span class="st">"nonmem"</span>, <span class="st">"complex"</span>, <span class="dt">package =</span> <span class="st">"rbabylon"</span>)</a>
 <a class="sourceLine" id="cb2-2" data-line-number="2"></a>
 <a class="sourceLine" id="cb2-3" data-line-number="3">sum1 &lt;-<span class="st"> </span></a>
 <a class="sourceLine" id="cb2-4" data-line-number="4"><span class="st">  </span><span class="kw"><a href="../reference/read_model.html">read_model</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/file.path.html">file.path</a></span>(MODEL_DIR, <span class="st">"iovmm"</span>)) <span class="op">%&gt;%</span></a>
 <a class="sourceLine" id="cb2-5" data-line-number="5"><span class="st">  </span><span class="kw"><a href="../reference/model_summary.html">model_summary</a></span>()</a>
 <a class="sourceLine" id="cb2-6" data-line-number="6"></a>
 <a class="sourceLine" id="cb2-7" data-line-number="7"><span class="kw"><a href="https://rdrr.io/r/base/names.html">names</a></span>(sum1)</a>
-<a class="sourceLine" id="cb2-8" data-line-number="8"><span class="co">#&gt; [1] "run_details"       "run_heuristics"    "parameters_data"  </span></a>
-<a class="sourceLine" id="cb2-9" data-line-number="9"><span class="co">#&gt; [4] "parameter_names"   "ofv"               "condition_number" </span></a>
-<a class="sourceLine" id="cb2-10" data-line-number="10"><span class="co">#&gt; [7] "shrinkage_details"</span></a></code></pre></div>
+<a class="sourceLine" id="cb2-8" data-line-number="8"><span class="co">#&gt; [1] "absolute_model_path" "run_details"         "run_heuristics"     </span></a>
+<a class="sourceLine" id="cb2-9" data-line-number="9"><span class="co">#&gt; [4] "parameters_data"     "parameter_names"     "ofv"                </span></a>
+<a class="sourceLine" id="cb2-10" data-line-number="10"><span class="co">#&gt; [7] "condition_number"    "shrinkage_details"</span></a></code></pre></div>
 <p>For example, the <code>run_details</code> section alone contains wealth of information about this model run:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1"><span class="kw"><a href="https://rdrr.io/r/utils/str.html">str</a></span>(sum1<span class="op">$</span>run_details)</a>
 <a class="sourceLine" id="cb3-2" data-line-number="2"><span class="co">#&gt; List of 16</span></a>
@@ -196,37 +196,40 @@
 <a href="#run-details-columns" class="anchor"></a>Run Details Columns</h2>
 <p>The next batch of columns contain the core diagnostics and model outputs. As mentioned above, descriptions of what each column contains can be found in the <a href="https://metrumresearchgroup.github.io/rbabylon/reference/summary_log.html"><code><a href="../reference/summary_log.html">summary_log()</a></code> docs</a>.</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1">sum_df <span class="op">%&gt;%</span><span class="st"> </span></a>
-<a class="sourceLine" id="cb5-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(</a>
-<a class="sourceLine" id="cb5-3" data-line-number="3">    run,</a>
-<a class="sourceLine" id="cb5-4" data-line-number="4">    ofv, </a>
-<a class="sourceLine" id="cb5-5" data-line-number="5">    param_count, </a>
-<a class="sourceLine" id="cb5-6" data-line-number="6">    estimation_method, </a>
-<a class="sourceLine" id="cb5-7" data-line-number="7">    problem_text, </a>
-<a class="sourceLine" id="cb5-8" data-line-number="8">    number_of_patients, </a>
-<a class="sourceLine" id="cb5-9" data-line-number="9">    number_of_obs, </a>
-<a class="sourceLine" id="cb5-10" data-line-number="10">    condition_number</a>
-<a class="sourceLine" id="cb5-11" data-line-number="11">  )</a>
-<a class="sourceLine" id="cb5-12" data-line-number="12"><span class="co">#&gt; # A tibble: 3 x 8</span></a>
-<a class="sourceLine" id="cb5-13" data-line-number="13"><span class="co">#&gt;   run       ofv param_count estimation_meth… problem_text number_of_patie…</span></a>
-<a class="sourceLine" id="cb5-14" data-line-number="14"><span class="co">#&gt;   &lt;chr&gt;   &lt;dbl&gt;       &lt;int&gt; &lt;list&gt;           &lt;chr&gt;                   &lt;int&gt;</span></a>
-<a class="sourceLine" id="cb5-15" data-line-number="15"><span class="co">#&gt; 1 1001    3843.          15 &lt;chr [1]&gt;        Run# 1001.1               240</span></a>
-<a class="sourceLine" id="cb5-16" data-line-number="16"><span class="co">#&gt; 2 exam… -10839.          21 &lt;chr [2]&gt;        RUN# exampl…              400</span></a>
-<a class="sourceLine" id="cb5-17" data-line-number="17"><span class="co">#&gt; 3 iovmm  14722.          11 &lt;chr [1]&gt;        LEM 10 mixt…              300</span></a>
-<a class="sourceLine" id="cb5-18" data-line-number="18"><span class="co">#&gt; # … with 2 more variables: number_of_obs &lt;int&gt;, condition_number &lt;dbl&gt;</span></a></code></pre></div>
+<a class="sourceLine" id="cb5-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="../reference/collapse_to_string.html">collapse_to_string</a></span>(estimation_method) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb5-3" data-line-number="3"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(</a>
+<a class="sourceLine" id="cb5-4" data-line-number="4">    run,</a>
+<a class="sourceLine" id="cb5-5" data-line-number="5">    ofv, </a>
+<a class="sourceLine" id="cb5-6" data-line-number="6">    param_count, </a>
+<a class="sourceLine" id="cb5-7" data-line-number="7">    estimation_method, </a>
+<a class="sourceLine" id="cb5-8" data-line-number="8">    problem_text, </a>
+<a class="sourceLine" id="cb5-9" data-line-number="9">    number_of_patients, </a>
+<a class="sourceLine" id="cb5-10" data-line-number="10">    number_of_obs, </a>
+<a class="sourceLine" id="cb5-11" data-line-number="11">    condition_number</a>
+<a class="sourceLine" id="cb5-12" data-line-number="12">  )</a>
+<a class="sourceLine" id="cb5-13" data-line-number="13"><span class="co">#&gt; # A tibble: 4 x 8</span></a>
+<a class="sourceLine" id="cb5-14" data-line-number="14"><span class="co">#&gt;   run       ofv param_count estimation_meth… problem_text number_of_patie…</span></a>
+<a class="sourceLine" id="cb5-15" data-line-number="15"><span class="co">#&gt;   &lt;chr&gt;   &lt;dbl&gt;       &lt;int&gt; &lt;chr&gt;            &lt;chr&gt;                   &lt;int&gt;</span></a>
+<a class="sourceLine" id="cb5-16" data-line-number="16"><span class="co">#&gt; 1 1001    3843.          15 MCMC Bayesian A… Run# 1001.1               240</span></a>
+<a class="sourceLine" id="cb5-17" data-line-number="17"><span class="co">#&gt; 2 acop…  44159.           9 First Order Con… LEM PK mode…               39</span></a>
+<a class="sourceLine" id="cb5-18" data-line-number="18"><span class="co">#&gt; 3 exam… -10839.          21 Stochastic Appr… RUN# exampl…              400</span></a>
+<a class="sourceLine" id="cb5-19" data-line-number="19"><span class="co">#&gt; 4 iovmm  14722.          11 First Order Con… LEM 10 mixt…              300</span></a>
+<a class="sourceLine" id="cb5-20" data-line-number="20"><span class="co">#&gt; # … with 2 more variables: number_of_obs &lt;int&gt;, condition_number &lt;dbl&gt;</span></a></code></pre></div>
 </div>
 <div id="run-heuristics-columns" class="section level2">
 <h2 class="hasAnchor">
 <a href="#run-heuristics-columns" class="anchor"></a>Run Heuristics Columns</h2>
 <p>The <code>run_heuristics</code> element of the <code>bbi_nonmem_summary</code> object contains a number of logical values indicating whether particular heuristic issues were found in the model. Note that these are not necessarily <em>errors</em> with the model run, but are closer to warning flags that should possibly be investigated. Each heuristic is described in more detail in the <a href="https://metrumresearchgroup.github.io/rbabylon/reference/summary_log.html"><code><a href="../reference/summary_log.html">summary_log()</a></code> docs</a>.</p>
 <p>Note that <strong>all heuristics will be <code>FALSE</code> by default (and <em>never</em> <code>NA</code>) and will only be <code>TRUE</code> if they are explicitly triggered.</strong> For example, <code>large_condition_number</code> will be <code>FALSE</code> even in the case when a condition number was not calculated at all.</p>
-<p>All of the heuristic flags are pivoted out to their own columns in the <code>bbi_summary_log_df</code> tibble. It’s useful to note that, except for <code>needed_fail_flags</code> (discussed above), these are the <em>only logical columns</em> in the tibble and can therefore be easily selected with <code>tidyselect::where(is.logical)</code>. <em>(Note: <code>where()</code> only became available in <code>tidyselect (&gt;= 1.1.0)</code>, released May 2020.)</em></p>
-<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">sum_df <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(run, <span class="kw">where</span>(is.logical), <span class="op">-</span>needed_fail_flags)</a></code></pre></div>
-<pre><code>#&gt; # A tibble: 3 x 12
+<p>All of the heuristic flags are pivoted out to their own columns in the <code>bbi_summary_log_df</code> tibble. It’s useful to note that, except for <code>needed_fail_flags</code> (discussed above), these are the <em>only logical columns</em> in the tibble and can therefore be easily selected with <code><a href="https://tidyselect.r-lib.org/reference/where.html">tidyselect::where(is.logical)</a></code>. <em>(Note: <code><a href="https://tidyselect.r-lib.org/reference/where.html">where()</a></code> only became available in <code>tidyselect (&gt;= 1.1.0)</code>, released May 2020.)</em></p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">sum_df <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(run, <span class="kw"><a href="https://tidyselect.r-lib.org/reference/where.html">where</a></span>(is.logical), <span class="op">-</span>needed_fail_flags)</a></code></pre></div>
+<pre><code>#&gt; # A tibble: 4 x 12
 #&gt;   run   needed_fail_fla… any_heuristics covariance_step… large_condition…
 #&gt;   &lt;chr&gt; &lt;lgl&gt;            &lt;lgl&gt;          &lt;lgl&gt;            &lt;lgl&gt;           
 #&gt; 1 1001  TRUE             TRUE           FALSE            TRUE            
-#&gt; 2 exam… FALSE            FALSE          FALSE            FALSE           
-#&gt; 3 iovmm FALSE            TRUE           FALSE            FALSE           
+#&gt; 2 acop… FALSE            TRUE           FALSE            FALSE           
+#&gt; 3 exam… FALSE            FALSE          FALSE            FALSE           
+#&gt; 4 iovmm FALSE            TRUE           FALSE            FALSE           
 #&gt; # … with 7 more variables: correlations_not_ok &lt;lgl&gt;,
 #&gt; #   parameter_near_boundary &lt;lgl&gt;, hessian_reset &lt;lgl&gt;,
 #&gt; #   has_final_zero_gradient &lt;lgl&gt;, minimization_terminated &lt;lgl&gt;,
@@ -249,8 +252,8 @@
 <a class="sourceLine" id="cb8-9" data-line-number="9"><span class="co">#&gt; # A tibble: 2 x 5</span></a>
 <a class="sourceLine" id="cb8-10" data-line-number="10"><span class="co">#&gt;   run              tags       ofv param_count any_heuristics</span></a>
 <a class="sourceLine" id="cb8-11" data-line-number="11"><span class="co">#&gt;   &lt;chr&gt;            &lt;list&gt;   &lt;dbl&gt;       &lt;int&gt; &lt;lgl&gt;         </span></a>
-<a class="sourceLine" id="cb8-12" data-line-number="12"><span class="co">#&gt; 1 example2_saemimp &lt;NULL&gt; -10839.          21 FALSE         </span></a>
-<a class="sourceLine" id="cb8-13" data-line-number="13"><span class="co">#&gt; 2 iovmm            &lt;NULL&gt;  14722.          11 TRUE</span></a></code></pre></div>
+<a class="sourceLine" id="cb8-12" data-line-number="12"><span class="co">#&gt; 1 acop-iov         &lt;NULL&gt;  44159.           9 TRUE          </span></a>
+<a class="sourceLine" id="cb8-13" data-line-number="13"><span class="co">#&gt; 2 example2_saemimp &lt;NULL&gt; -10839.          21 FALSE</span></a></code></pre></div>
 </div>
   </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -84,7 +84,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -119,7 +119,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,7 +40,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -48,7 +48,7 @@
       <ul class="nav navbar-nav">
 <li>
   <a href="index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -83,7 +83,7 @@
 <ul class="nav navbar-nav navbar-right">
 <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -132,6 +132,17 @@
 <a href="https://metrumresearchgroup.github.io/rbabylon/articles/using-summary-log.html">Creating a Model Summary Log</a> – How to use <code><a href="reference/summary_log.html">summary_log()</a></code> to extract model diagnostics like the objective function value, condition number, and parameter counts.</li>
 </ul>
 </div>
+</div>
+<div id="development" class="section level2">
+<h2 class="hasAnchor">
+<a href="#development" class="anchor"></a>Development</h2>
+<p><code>rbabylon</code> uses <a href="https://github.com/metrumresearchgroup/pkgr">pkgr</a> to manage development dependencies and <a href="https://rstudio.github.io/renv/">renv</a> to provide isolation. To replicate this environment,</p>
+<ol>
+<li><p>clone the repo</p></li>
+<li><p>install pkgr</p></li>
+<li><p>run <code>pkgr install</code></p></li>
+</ol>
+<p>Then, launch R with the repo as the working directory (open the project in RStudio). renv will activate and find the project library.</p>
 </div>
 </div>
   </div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -84,7 +84,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -119,7 +119,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -140,12 +140,34 @@
       
     </div>
 
-    <div id="rbabylon-0-10-0" class="section level1">
+    <div id="rbabylon-0-11-0" class="section level1">
 <h1 class="page-header">
-<a href="#rbabylon-0-10-0" class="anchor"></a>rbabylon 0.10.0</h1>
+<a href="#rbabylon-0-11-0" class="anchor"></a>rbabylon 0.11.0</h1>
 <div id="new-features-and-changes" class="section level2">
 <h2 class="hasAnchor">
 <a href="#new-features-and-changes" class="anchor"></a>New features and changes</h2>
+<ul>
+<li><p>Added print methods for <code>bbi_nonmem_summary</code> and <code>babylon_process</code> objects. The <code>bbi_nonmem_summary</code> object should print nicely in the console, and also look good in <code>.Rmd</code> chunks with the option <code>results = 'asis'</code>. (#298 and #294)</p></li>
+<li><p>The <code>bbi_nonmem_summary</code> object now contains the <code>absolute_model_path</code> and we have added the following methods to work on that object (these previously only worked on <code>bbi_nonmem_model</code> objects): <code><a href="../reference/get_model_id.html">get_model_id()</a></code>, <code><a href="../reference/get_path_from_object.html">get_model_path()</a></code>, <code><a href="../reference/get_path_from_object.html">get_output_dir()</a></code>, <code><a href="../reference/get_path_from_object.html">get_yaml_path()</a></code>, <code><a href="../reference/check_nonmem_table_output.html">check_grd()</a></code>, <code><a href="../reference/check_nonmem_table_output.html">check_ext()</a></code>. (#297)</p></li>
+<li><p>For developers, there are now scripts in <code>data-raw</code> which regenerate the test reference files and re-run the test models. All test references and example files have now been consolidated in <code>inst</code> as well. Users will see these files in <code>extdata</code>, <code>model</code>, and <code>test-refs</code> when the package is installed. (#289)</p></li>
+<li><p>Also for developers, we are now using <code>pkgr</code> and <code>renv</code> to isolate dependencies when developing. The <code>README</code> has been updated with instructions for how to use this when developing. (#276)</p></li>
+</ul>
+</div>
+<div id="bug-fixes" class="section level2">
+<h2 class="hasAnchor">
+<a href="#bug-fixes" class="anchor"></a>Bug fixes</h2>
+<ul>
+<li><p>Previously <code><a href="../reference/modify_model_field.html">replace_model_field()</a></code>, which is called under the hood by <code><a href="../reference/modify_tags.html">replace_tag()</a></code> and <code><a href="../reference/modify_notes.html">replace_note()</a></code> did <em>not</em> modify the YAML file as it should have. That has been fixed. (#281)</p></li>
+<li><p>Previously the <code><a href="../reference/summary_log.html">add_summary()</a></code> function would error if all the model summaries errored. Now it will return, passing through the model summary errors to the tibble, as it should. (#282)</p></li>
+</ul>
+</div>
+</div>
+    <div id="rbabylon-0-10-0" class="section level1">
+<h1 class="page-header">
+<a href="#rbabylon-0-10-0" class="anchor"></a>rbabylon 0.10.0</h1>
+<div id="new-features-and-changes-1" class="section level2">
+<h2 class="hasAnchor">
+<a href="#new-features-and-changes-1" class="anchor"></a>New features and changes</h2>
 <ul>
 <li><p>Deprecated <code><a href="../reference/modify_tags.html">replace_tags()</a></code>, <code><a href="../reference/modify_bbi_args.html">replace_bbi_args()</a></code>, and <code><a href="../reference/modify_based_on.html">replace_based_on()</a></code> and replaced them with <code>replace_all_</code> variants. These functions will warn about this for two more releases and then begin to error for two more releases before being removed altogether. (#264)</p></li>
 <li><p>Added <code><a href="../reference/modify_tags.html">replace_tag()</a></code> (singular) which replaces a single tag with a new tag. <code><a href="../reference/modify_notes.html">replace_note()</a></code> (mentioned below) functions the same way. (#264)</p></li>
@@ -157,9 +179,9 @@
 <li><p>Added <code><a href="../reference/modify_tags.html">remove_tags()</a></code>, <code><a href="../reference/modify_notes.html">remove_notes()</a></code>, and <code><a href="../reference/modify_based_on.html">remove_based_on()</a></code> functions for removing specific strings from the relevant model object field. (#252)</p></li>
 </ul>
 </div>
-<div id="bug-fixes" class="section level2">
+<div id="bug-fixes-1" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fixes" class="anchor"></a>Bug fixes</h2>
+<a href="#bug-fixes-1" class="anchor"></a>Bug fixes</h2>
 <ul>
 <li><p><code><a href="../reference/submit_models.html">submit_models()</a></code> correctly handles the case where bbi arguments are neither present in the YAML file nor passed at runtime (#248).</p></li>
 <li><p><code><a href="../reference/config_log.html">config_log()</a></code> and <code><a href="../reference/config_log.html">add_config()</a></code> are supposed to warn a user if models are found that do <em>not</em> have a corresponding <code>bbi_config.json</code> file (i.e. have not yet been run, or did not finish successfully). However, if there is no output directory at all for a given model (it has never been run) then these functions would error. Now they correctly warn in that scenario. (#253)</p></li>
@@ -225,6 +247,7 @@
     <div id="tocnav">
       <h2>Contents</h2>
       <ul class="nav nav-pills nav-stacked">
+        <li><a href="#rbabylon-0-11-0">0.11.0</a></li>
         <li><a href="#rbabylon-0-10-0">0.10.0</a></li>
         <li><a href="#rbabylon-0-9-0">0.9.0</a></li>
         <li><a href="#rbabylon-0-8-0">0.8.0</a></li>

--- a/docs/reference/add_log_impl.html
+++ b/docs/reference/add_log_impl.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/add_param_shrinkage.html
+++ b/docs/reference/add_param_shrinkage.html
@@ -78,7 +78,7 @@ with the shrinkage assigned to the relevant parameters." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ with the shrinkage assigned to the relevant parameters." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ with the shrinkage assigned to the relevant parameters." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/add_run_id_col.html
+++ b/docs/reference/add_run_id_col.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/apply_indices.html
+++ b/docs/reference/apply_indices.html
@@ -79,7 +79,7 @@ to the output of the param_labels() function and are instead added with the  app
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -87,7 +87,7 @@ to the output of the param_labels() function and are instead added with the  app
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -122,7 +122,7 @@ to the output of the param_labels() function and are instead added with the  app
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/as_summary_list.html
+++ b/docs/reference/as_summary_list.html
@@ -80,7 +80,7 @@ Note this is primarily intended as a developer function, though it was exposed b
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -88,7 +88,7 @@ Note this is primarily intended as a developer function, though it was exposed b
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -123,7 +123,7 @@ Note this is primarily intended as a developer function, though it was exposed b
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/bbi_current_release.html
+++ b/docs/reference/bbi_current_release.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/bbi_dry_run.html
+++ b/docs/reference/bbi_dry_run.html
@@ -78,7 +78,7 @@ Also contains the element call with a string representing the command that could
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ Also contains the element call with a string representing the command that could
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ Also contains the element call with a string representing the command that could
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/bbi_exec.html
+++ b/docs/reference/bbi_exec.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/bbi_help.html
+++ b/docs/reference/bbi_help.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/bbi_init.html
+++ b/docs/reference/bbi_init.html
@@ -79,7 +79,7 @@ that directory." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -87,7 +87,7 @@ that directory." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -122,7 +122,7 @@ that directory." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/bbi_version.html
+++ b/docs/reference/bbi_version.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/build_bbi_param_list.html
+++ b/docs/reference/build_bbi_param_list.html
@@ -78,7 +78,7 @@ working directory and a set of CLI arguments." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ working directory and a set of CLI arguments." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ working directory and a set of CLI arguments." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/build_matrix_indices.html
+++ b/docs/reference/build_matrix_indices.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/build_new_model_path.html
+++ b/docs/reference/build_new_model_path.html
@@ -83,7 +83,7 @@ be treated as relative to the working directory of .parent_mod." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -91,7 +91,7 @@ be treated as relative to the working directory of .parent_mod." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -126,7 +126,7 @@ be treated as relative to the working directory of .parent_mod." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/build_path_from_mod_obj.html
+++ b/docs/reference/build_path_from_mod_obj.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -153,7 +153,7 @@
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>.mod</th>
-      <td><p><code>bbi_{.model_type}_model</code> object</p></td>
+      <td><p>Model to use, either a <code>bbi_{.model_type}_model</code> or <code>bbi_{.model_type}_summary</code> object.</p></td>
     </tr>
     <tr>
       <th>.extension</th>

--- a/docs/reference/check_bbi_args.html
+++ b/docs/reference/check_bbi_args.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/check_bbi_exe.html
+++ b/docs/reference/check_bbi_exe.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/check_bbi_run_log_df_object.html
+++ b/docs/reference/check_bbi_run_log_df_object.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/check_bbi_version_constraint.html
+++ b/docs/reference/check_bbi_version_constraint.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/check_file.html
+++ b/docs/reference/check_file.html
@@ -78,7 +78,7 @@ This is called internally in several S3 methods described below." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ This is called internally in several S3 methods described below." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ This is called internally in several S3 methods described below." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/check_lst_file.html
+++ b/docs/reference/check_lst_file.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/check_model_object.html
+++ b/docs/reference/check_model_object.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/check_model_object_list.html
+++ b/docs/reference/check_model_object_list.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/check_nonmem_table_bbi.html
+++ b/docs/reference/check_nonmem_table_bbi.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Check if diagonal index or not — is_diag • rbabylon</title>
+<title>Private helper to pull a NONMEM table from a model — check_nonmem_table_bbi • rbabylon</title>
 
 <!-- favicons -->
 <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
@@ -42,8 +42,8 @@
 
 
 
-<meta property="og:title" content="Check if diagonal index or not — is_diag" />
-<meta property="og:description" content="Private helper to unpack a matrix index string like '(3,3)' is for a diagonal (i.e. if the numbers are the same)" />
+<meta property="og:title" content="Private helper to pull a NONMEM table from a model — check_nonmem_table_bbi" />
+<meta property="og:description" content="Private helper to pull a NONMEM table from a model" />
 <meta property="og:image" content="https://metrumresearchgroup.github.io/rbabylon/logo.png" />
 <meta name="twitter:card" content="summary" />
 
@@ -137,32 +137,23 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Check if diagonal index or not</h1>
+    <h1>Private helper to pull a NONMEM table from a model</h1>
     
-    <div class="hidden name"><code>is_diag.Rd</code></div>
+    <div class="hidden name"><code>check_nonmem_table_bbi.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    <p>Private helper to unpack a matrix index string like '(3,3)' is for a diagonal (i.e. if the numbers are the same)</p>
+    <p>Private helper to pull a NONMEM table from a model</p>
     </div>
 
-    <pre class="usage"><span class='fu'>is_diag</span>(<span class='no'>.name</span>)</pre>
+    <pre class="usage"><span class='fu'>check_nonmem_table_bbi</span>(<span class='no'>.mod</span>, <span class='no'>.iter_floor</span>, <span class='no'>.extension</span>)</pre>
 
-    <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
-    <table class="ref-arguments">
-    <colgroup><col class="name" /><col class="desc" /></colgroup>
-    <tr>
-      <th>.name</th>
-      <td><p>A character scalar containing an index string</p></td>
-    </tr>
-    </table>
 
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>
     <ul class="nav nav-pills nav-stacked">
-      <li><a href="#arguments">Arguments</a></li>
     </ul>
 
   </div>

--- a/docs/reference/check_nonmem_table_output.html
+++ b/docs/reference/check_nonmem_table_output.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -156,12 +156,18 @@
 <span class='co'># S3 method for bbi_nonmem_model</span>
 <span class='fu'>check_grd</span>(<span class='no'>.mod</span>, <span class='kw'>.iter_floor</span> <span class='kw'>=</span> <span class='fl'>0</span>)
 
+<span class='co'># S3 method for bbi_nonmem_summary</span>
+<span class='fu'>check_grd</span>(<span class='no'>.mod</span>, <span class='kw'>.iter_floor</span> <span class='kw'>=</span> <span class='fl'>0</span>)
+
 <span class='fu'>check_ext</span>(<span class='no'>.mod</span>, <span class='kw'>.iter_floor</span> <span class='kw'>=</span> <span class='fl'>0</span>)
 
 <span class='co'># S3 method for character</span>
 <span class='fu'>check_ext</span>(<span class='no'>.mod</span>, <span class='kw'>.iter_floor</span> <span class='kw'>=</span> <span class='fl'>0</span>)
 
 <span class='co'># S3 method for bbi_nonmem_model</span>
+<span class='fu'>check_ext</span>(<span class='no'>.mod</span>, <span class='kw'>.iter_floor</span> <span class='kw'>=</span> <span class='fl'>0</span>)
+
+<span class='co'># S3 method for bbi_nonmem_summary</span>
 <span class='fu'>check_ext</span>(<span class='no'>.mod</span>, <span class='kw'>.iter_floor</span> <span class='kw'>=</span> <span class='fl'>0</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
@@ -195,8 +201,10 @@
 <ul>
 <li><p><code>check_grd</code>: Checks .grd file from a file path</p></li>
 <li><p><code>check_grd</code>: Checks .grd file from a <code>bbi_nonmem_model</code></p></li>
+<li><p><code>check_grd</code>: Checks .grd file from a <code>bbi_nonmem_summary</code></p></li>
 <li><p><code>check_ext</code>: Checks .ext file from a file path</p></li>
 <li><p><code>check_ext</code>: Checks .ext file from a <code>bbi_nonmem_model</code> object</p></li>
+<li><p><code>check_ext</code>: Checks .ext file from a <code>bbi_nonmem_summary</code> object</p></li>
 </ul>
 
   </div>

--- a/docs/reference/check_output_dir.html
+++ b/docs/reference/check_output_dir.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/check_status_code.html
+++ b/docs/reference/check_status_code.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/clean_ctl.html
+++ b/docs/reference/clean_ctl.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/collapse_to_string.html
+++ b/docs/reference/collapse_to_string.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -191,12 +191,12 @@ trigger a warning notifying the user that only list columns can be collapsed.</p
   <span class='kw'>list_list</span>  <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/list.html'>list</a></span>(<span class='fu'><a href='https://rdrr.io/r/base/list.html'>list</a></span>(<span class='kw'>a</span><span class='kw'>=</span><span class='fl'>1</span>, <span class='kw'>b</span><span class='kw'>=</span><span class='fl'>2</span>, <span class='kw'>c</span><span class='kw'>=</span><span class='fl'>3</span>), <span class='kw'>NULL</span>, <span class='fu'><a href='https://rdrr.io/r/base/list.html'>list</a></span>(<span class='kw'>z</span><span class='kw'>=</span>-<span class='fl'>1</span>, <span class='kw'>y</span><span class='kw'>=</span>-<span class='fl'>2</span>, <span class='kw'>x</span><span class='kw'>=</span>-<span class='fl'>3</span>))
 )
 
-<span class='fu'>collapse_to_string</span>(<span class='no'>df</span>, <span class='no'>char_list</span>, <span class='no'>num_list</span>, <span class='no'>list_list</span>)</div><div class='output co'>#&gt; <span style='color: #555555;'># A tibble: 3 x 4</span><span>
+<span class='fu'>collapse_to_string</span>(<span class='no'>df</span>, <span class='no'>char_list</span>, <span class='no'>num_list</span>, <span class='no'>list_list</span>)</div><div class='output co'>#&gt; <span style='color: #949494;'># A tibble: 3 x 4</span><span>
 #&gt;   row_num char_list num_list   list_list                   
-#&gt;     </span><span style='color: #555555;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #555555;font-style: italic;'>&lt;chr&gt;</span><span>     </span><span style='color: #555555;font-style: italic;'>&lt;chr&gt;</span><span>      </span><span style='color: #555555;font-style: italic;'>&lt;chr&gt;</span><span>                       
-#&gt; </span><span style='color: #555555;'>1</span><span>       1 foo, bar  23, 34, 45 list(a = 1, b = 2, c = 3)   
-#&gt; </span><span style='color: #555555;'>2</span><span>       2 baz       -1, -2, -3 </span><span style='color: #BB0000;'>NA</span><span>                          
-#&gt; </span><span style='color: #555555;'>3</span><span>       3 naw, dawg </span><span style='color: #BB0000;'>NA</span><span>         list(z = -1, y = -2, x = -3)</div><div class='input'>
+#&gt;     </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #949494;font-style: italic;'>&lt;chr&gt;</span><span>     </span><span style='color: #949494;font-style: italic;'>&lt;chr&gt;</span><span>      </span><span style='color: #949494;font-style: italic;'>&lt;chr&gt;</span><span>                       
+#&gt; </span><span style='color: #BCBCBC;'>1</span><span>       1 foo, bar  23, 34, 45 list(a = 1, b = 2, c = 3)   
+#&gt; </span><span style='color: #BCBCBC;'>2</span><span>       2 baz       -1, -2, -3 </span><span style='color: #BB0000;'>NA</span><span>                          
+#&gt; </span><span style='color: #BCBCBC;'>3</span><span>       3 naw, dawg </span><span style='color: #BB0000;'>NA</span><span>         list(z = -1, y = -2, x = -3)</div><div class='input'>
 </div></span></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">

--- a/docs/reference/combine_directory_path.html
+++ b/docs/reference/combine_directory_path.html
@@ -81,7 +81,7 @@ Also NOTE that .directory must point an already existing directory so that the a
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -89,7 +89,7 @@ Also NOTE that .directory must point an already existing directory so that the a
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -124,7 +124,7 @@ Also NOTE that .directory must point an already existing directory so that the a
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/combine_list_objects.html
+++ b/docs/reference/combine_list_objects.html
@@ -80,7 +80,7 @@ Any S3 classes will be inherited with those from .new_list given precedence." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -88,7 +88,7 @@ Any S3 classes will be inherited with those from .new_list given precedence." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -123,7 +123,7 @@ Any S3 classes will be inherited with those from .new_list given precedence." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/config_log.html
+++ b/docs/reference/config_log.html
@@ -79,7 +79,7 @@ run." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -87,7 +87,7 @@ run." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -122,7 +122,7 @@ run." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -173,7 +173,9 @@ run.</p>
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
-    <p>An object of class <code>bbi_config_log_df</code>, which includes the fields described below.</p>
+    <p>An object of class <code>bbi_config_log_df</code>, which includes the fields described below.
+If <em>no</em> <code>bbi_config.json</code> files are found, the returned tibble will only contain the
+<code>absolute_model_path</code> and <code>run</code> columns, and will have 0 rows.</p>
 <p><code>config_log()</code> creates a new tibble with one row per <code>bbi_config.json</code>
 found in <code>.base_dir</code> (and subdirectories, if <code>.recurse = TRUE</code>).</p>
 <p><code>add_config()</code> adds these fields to the tibble passed to <code>.log_df</code>.</p>

--- a/docs/reference/config_log_entry.html
+++ b/docs/reference/config_log_entry.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/config_log_impl.html
+++ b/docs/reference/config_log_impl.html
@@ -78,7 +78,7 @@ This is called by both config_log() and add_config()." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ This is called by both config_log() and add_config()." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ This is called by both config_log() and add_config()." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/copy_control_stream.html
+++ b/docs/reference/copy_control_stream.html
@@ -78,7 +78,7 @@ Note that any file existing at .new_model_path will be overwritten." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ Note that any file existing at .new_model_path will be overwritten." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ Note that any file existing at .new_model_path will be overwritten." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/copy_model_from.html
+++ b/docs/reference/copy_model_from.html
@@ -79,7 +79,7 @@ ancestry. See &quot;Using based_on field&quot; vignette for details." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -87,7 +87,7 @@ ancestry. See &quot;Using based_on field&quot; vignette for details." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -122,7 +122,7 @@ ancestry. See &quot;Using based_on field&quot; vignette for details." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/copy_nonmem_model_from.html
+++ b/docs/reference/copy_nonmem_model_from.html
@@ -79,7 +79,7 @@ Also fills in necessary YAML fields for using run_log() later." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -87,7 +87,7 @@ Also fills in necessary YAML fields for using run_log() later." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -122,7 +122,7 @@ Also fills in necessary YAML fields for using run_log() later." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/create_bbi_object.html
+++ b/docs/reference/create_bbi_object.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/current_release.html
+++ b/docs/reference/current_release.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/extract_from_summary.html
+++ b/docs/reference/extract_from_summary.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/file_matches.html
+++ b/docs/reference/file_matches.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/find_models.html
+++ b/docs/reference/find_models.html
@@ -78,7 +78,7 @@ and attempts to read them to a model object with safe_read_model()." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ and attempts to read them to a model object with safe_read_model()." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ and attempts to read them to a model object with safe_read_model()." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/find_nonmem_model_file_path.html
+++ b/docs/reference/find_nonmem_model_file_path.html
@@ -80,7 +80,7 @@ If neither exists and .check_exists = TRUE, throw an error." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -88,7 +88,7 @@ If neither exists and .check_exists = TRUE, throw an error." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -123,7 +123,7 @@ If neither exists and .check_exists = TRUE, throw an error." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/format_cmd_args.html
+++ b/docs/reference/format_cmd_args.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/get_based_on.html
+++ b/docs/reference/get_based_on.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/get_model_id.html
+++ b/docs/reference/get_model_id.html
@@ -78,7 +78,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -154,6 +154,9 @@
 <span class='fu'>get_model_id</span>(<span class='no'>.mod</span>)
 
 <span class='co'># S3 method for bbi_nonmem_model</span>
+<span class='fu'>get_model_id</span>(<span class='no'>.mod</span>)
+
+<span class='co'># S3 method for bbi_nonmem_summary</span>
 <span class='fu'>get_model_id</span>(<span class='no'>.mod</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
@@ -161,7 +164,8 @@
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>.mod</th>
-      <td><p>Model to use, either a <code>bbi_{.model_type}_model</code> or file path to a model.</p></td>
+      <td><p>Model to use, either a <code>bbi_{.model_type}_model</code> or
+<code>bbi_{.model_type}_summary</code>, or a file path to a model.</p></td>
     </tr>
     </table>
 
@@ -174,6 +178,7 @@
 <ul>
 <li><p><code>character</code>: Takes file path to model.</p></li>
 <li><p><code>bbi_nonmem_model</code>: Takes <code>bbi_nonmem_model</code> object</p></li>
+<li><p><code>bbi_nonmem_summary</code>: Takes <code>bbi_nonmem_summary</code> object</p></li>
 </ul>
 
   </div>

--- a/docs/reference/get_model_working_directory.html
+++ b/docs/reference/get_model_working_directory.html
@@ -78,7 +78,7 @@ absolute model path." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ absolute model path." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ absolute model path." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -155,7 +155,7 @@ absolute model path.</p>
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>.mod</th>
-      <td><p>A model object.</p></td>
+      <td><p>A bbi model or summary object.</p></td>
     </tr>
     </table>
 

--- a/docs/reference/get_path_from_log_df.html
+++ b/docs/reference/get_path_from_log_df.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/get_path_from_object.html
+++ b/docs/reference/get_path_from_object.html
@@ -78,7 +78,7 @@ provide an easy way to retrieve the absolute path to these files." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ provide an easy way to retrieve the absolute path to these files." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ provide an easy way to retrieve the absolute path to these files." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -153,6 +153,9 @@ provide an easy way to retrieve the absolute path to these files.</p>
 <span class='co'># S3 method for bbi_nonmem_model</span>
 <span class='fu'>get_model_path</span>(<span class='no'>.bbi_object</span>, <span class='kw'>.check_exists</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
 
+<span class='co'># S3 method for bbi_nonmem_summary</span>
+<span class='fu'>get_model_path</span>(<span class='no'>.bbi_object</span>, <span class='kw'>.check_exists</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
+
 <span class='co'># S3 method for bbi_log_df</span>
 <span class='fu'>get_model_path</span>(<span class='no'>.bbi_object</span>, <span class='kw'>.check_exists</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
 
@@ -161,12 +164,18 @@ provide an easy way to retrieve the absolute path to these files.</p>
 <span class='co'># S3 method for bbi_nonmem_model</span>
 <span class='fu'>get_output_dir</span>(<span class='no'>.bbi_object</span>, <span class='kw'>.check_exists</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
 
+<span class='co'># S3 method for bbi_nonmem_summary</span>
+<span class='fu'>get_output_dir</span>(<span class='no'>.bbi_object</span>, <span class='kw'>.check_exists</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
+
 <span class='co'># S3 method for bbi_log_df</span>
 <span class='fu'>get_output_dir</span>(<span class='no'>.bbi_object</span>, <span class='kw'>.check_exists</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
 
 <span class='fu'>get_yaml_path</span>(<span class='no'>.bbi_object</span>, <span class='kw'>.check_exists</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
 
 <span class='co'># S3 method for bbi_nonmem_model</span>
+<span class='fu'>get_yaml_path</span>(<span class='no'>.bbi_object</span>, <span class='kw'>.check_exists</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
+
+<span class='co'># S3 method for bbi_nonmem_summary</span>
 <span class='fu'>get_yaml_path</span>(<span class='no'>.bbi_object</span>, <span class='kw'>.check_exists</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
 
 <span class='co'># S3 method for bbi_log_df</span>
@@ -179,6 +188,7 @@ provide an easy way to retrieve the absolute path to these files.</p>
       <th>.bbi_object</th>
       <td><p>The object to query. Could be
 a <code>bbi_{.model_type}_model</code> object,
+<code>bbi_{.model_type}_summary</code> object,
 or a tibble of class <code>bbi_log_df</code>.</p></td>
     </tr>
     <tr>
@@ -187,12 +197,23 @@ or a tibble of class <code>bbi_log_df</code>.</p></td>
     </tr>
     </table>
 
+    <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
+
+    <p><strong><code>get_model_path()</code></strong> returns the path to the model definition file.
+For NONMEM models, this is the control stream.</p>
+<p><strong><code>get_output_dir()</code></strong> returns the path to the directory containing
+output files created when the model is run.</p>
+<p><strong><code>get_yaml_path()</code></strong> returns the path to the YAML file created by rbabylon.
+This file contains metadata like tags, etc. and should, generally speaking,
+<em>not</em> be interacted with directly. Use the helper functions mentioned in the
+<code><a href='modify_model_field.html'>modify_model_field()</a></code> help page to modify this file for you.</p>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>
     <ul class="nav nav-pills nav-stacked">
       <li><a href="#arguments">Arguments</a></li>
+      <li><a href="#details">Details</a></li>
     </ul>
 
   </div>

--- a/docs/reference/highlight_cell.html
+++ b/docs/reference/highlight_cell.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Check if diagonal index or not — is_diag • rbabylon</title>
+<title>Highlight cell in kable table — highlight_cell • rbabylon</title>
 
 <!-- favicons -->
 <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
@@ -42,8 +42,8 @@
 
 
 
-<meta property="og:title" content="Check if diagonal index or not — is_diag" />
-<meta property="og:description" content="Private helper to unpack a matrix index string like '(3,3)' is for a diagonal (i.e. if the numbers are the same)" />
+<meta property="og:title" content="Highlight cell in kable table — highlight_cell" />
+<meta property="og:description" content="Highlights in red numeric cells that are above the specified threshold." />
 <meta property="og:image" content="https://metrumresearchgroup.github.io/rbabylon/logo.png" />
 <meta name="twitter:card" content="summary" />
 
@@ -137,32 +137,45 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Check if diagonal index or not</h1>
+    <h1>Highlight cell in kable table</h1>
     
-    <div class="hidden name"><code>is_diag.Rd</code></div>
+    <div class="hidden name"><code>highlight_cell.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    <p>Private helper to unpack a matrix index string like '(3,3)' is for a diagonal (i.e. if the numbers are the same)</p>
+    <p>Highlights in red numeric cells that are above the specified threshold.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>is_diag</span>(<span class='no'>.name</span>)</pre>
+    <pre class="usage"><span class='fu'>highlight_cell</span>(<span class='no'>.l</span>, <span class='no'>.i</span>, <span class='no'>.threshold</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
-      <th>.name</th>
-      <td><p>A character scalar containing an index string</p></td>
+      <th>.l</th>
+      <td><p>character scalar of the line to be formatted (a row of a kable table)</p></td>
+    </tr>
+    <tr>
+      <th>.i</th>
+      <td><p>the index of the column to check</p></td>
+    </tr>
+    <tr>
+      <th>.threshold</th>
+      <td><p>the threshold to check against. If value is greater than
+.threshold then it is formatted as red.</p></td>
     </tr>
     </table>
 
+    <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
+
+    <p>character vector of formatted values</p>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>
     <ul class="nav nav-pills nav-stacked">
       <li><a href="#arguments">Arguments</a></li>
+      <li><a href="#value">Value</a></li>
     </ul>
 
   </div>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -84,7 +84,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -119,7 +119,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -334,6 +334,12 @@
           <p><code><a href="get_path_from_object.html">get_model_path()</a></code> <code><a href="get_path_from_object.html">get_output_dir()</a></code> <code><a href="get_path_from_object.html">get_yaml_path()</a></code> </p>
         </td>
         <td><p>Get path from bbi object</p></td>
+      </tr><tr>
+        
+        <td>
+          <p><code><a href="print_bbi.html">print(<i>&lt;babylon_process&gt;</i>)</a></code> <code><a href="print_bbi.html">print(<i>&lt;bbi_nonmem_summary&gt;</i>)</a></code> </p>
+        </td>
+        <td><p>Print methods for rbabylon objects</p></td>
       </tr>
     </tbody><tbody>
       <tr>

--- a/docs/reference/install_menu.html
+++ b/docs/reference/install_menu.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/is_valid_nonmem_extension.html
+++ b/docs/reference/is_valid_nonmem_extension.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/is_valid_yaml_extension.html
+++ b/docs/reference/is_valid_yaml_extension.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/linux_install_commands.html
+++ b/docs/reference/linux_install_commands.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/model_summaries.html
+++ b/docs/reference/model_summaries.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -225,6 +225,9 @@ or they are missing for some other legitimate reason, pass the appropriate flags
 <li><p><code>list</code>: Summarize a list of <code>bbi_{.model_type}_model</code> objects.</p></li>
 <li><p><code>bbi_run_log_df</code>: Takes a <code>bbi_run_log_df</code> tibble and summarizes all models in it.</p></li>
 </ul>
+    <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
+
+    <div class='dont-index'><p><code><a href='model_summary.html'>model_summary()</a></code></p></div>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
@@ -234,6 +237,7 @@ or they are missing for some other legitimate reason, pass the appropriate flags
       <li><a href="#value">Value</a></li>
       <li><a href="#details">Details</a></li>
       <li><a href="#methods-by-class-">Methods (by class)</a></li>
+      <li><a href="#see-also">See also</a></li>
     </ul>
 
   </div>

--- a/docs/reference/model_summary.html
+++ b/docs/reference/model_summary.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -177,6 +177,9 @@ See <code><a href='print_bbi_args.html'>print_bbi_args()</a></code> for full lis
 
     <p><strong>NONMEM</strong></p>
 <p>The returned list for a NONMEM model will contain the following top-level elements:</p><ul>
+<li><p><strong>absolute_model_path</strong> -- Absolute path to the model that generated this summary.
+Note, using this directly is discouraged in favor of using the "getters"
+described in the <code><a href='get_path_from_object.html'>get_path_from_object</a></code> help page.</p></li>
 <li><p><strong>run_details</strong> -- General details about the run including estimation
 method, numbers of patients and records, significant digits, run time, and
 more.</p></li>
@@ -219,6 +222,9 @@ For example, if have asked to skip the <code>$COV</code> step, you would call <c
 <ul>
 <li><p><code>bbi_nonmem_model</code>: Get model summary from <code>bbi_nonmem_model</code> object</p></li>
 </ul>
+    <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
+
+    <div class='dont-index'><p><code><a href='model_summaries.html'>model_summaries()</a></code></p></div>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
@@ -227,6 +233,7 @@ For example, if have asked to skip the <code>$COV</code> step, you would call <c
       <li><a href="#arguments">Arguments</a></li>
       <li><a href="#details">Details</a></li>
       <li><a href="#methods-by-class-">Methods (by class)</a></li>
+      <li><a href="#see-also">See also</a></li>
     </ul>
 
   </div>

--- a/docs/reference/modify_based_on.html
+++ b/docs/reference/modify_based_on.html
@@ -79,7 +79,7 @@ modified at any time (i.e. before or after a model is submitted)." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -87,7 +87,7 @@ modified at any time (i.e. before or after a model is submitted)." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -122,7 +122,7 @@ modified at any time (i.e. before or after a model is submitted)." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/modify_bbi_args.html
+++ b/docs/reference/modify_bbi_args.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/modify_decisions.html
+++ b/docs/reference/modify_decisions.html
@@ -84,7 +84,7 @@ removed two releases after that." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -92,7 +92,7 @@ removed two releases after that." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -127,7 +127,7 @@ removed two releases after that." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/modify_description.html
+++ b/docs/reference/modify_description.html
@@ -78,7 +78,7 @@ The description can be modified at any time (i.e. before or after a model is sub
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ The description can be modified at any time (i.e. before or after a model is sub
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ The description can be modified at any time (i.e. before or after a model is sub
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/modify_model_field.html
+++ b/docs/reference/modify_model_field.html
@@ -81,7 +81,7 @@ friendlier helpers listed below in &quot;See also&quot; whenever possible." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -89,7 +89,7 @@ friendlier helpers listed below in &quot;See also&quot; whenever possible." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -124,7 +124,7 @@ friendlier helpers listed below in &quot;See also&quot; whenever possible." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/modify_notes.html
+++ b/docs/reference/modify_notes.html
@@ -78,7 +78,7 @@ Notes can be modified at any time (i.e. before or after a model is submitted)." 
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ Notes can be modified at any time (i.e. before or after a model is submitted)." 
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ Notes can be modified at any time (i.e. before or after a model is submitted)." 
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/modify_tags.html
+++ b/docs/reference/modify_tags.html
@@ -78,7 +78,7 @@ Tags can be modified at any time (i.e. before or after a model is submitted)." /
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ Tags can be modified at any time (i.e. before or after a model is submitted)." /
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ Tags can be modified at any time (i.e. before or after a model is submitted)." /
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/na_to_null.html
+++ b/docs/reference/na_to_null.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/new_ext.html
+++ b/docs/reference/new_ext.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/new_model.html
+++ b/docs/reference/new_model.html
@@ -80,7 +80,7 @@ disk and throw an error if it doesn't find one." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -88,7 +88,7 @@ disk and throw an error if it doesn't find one." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -123,7 +123,7 @@ disk and throw an error if it doesn't find one." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/nonmem_summary.html
+++ b/docs/reference/nonmem_summary.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/param_estimates.html
+++ b/docs/reference/param_estimates.html
@@ -78,7 +78,7 @@ Details about the tibble that is returned are in the return value section below.
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ Details about the tibble that is returned are in the return value section below.
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ Details about the tibble that is returned are in the return value section below.
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/param_labels.html
+++ b/docs/reference/param_labels.html
@@ -79,7 +79,7 @@ The syntax for the labeling is described in &quot;Details&quot; below." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -87,7 +87,7 @@ The syntax for the labeling is described in &quot;Details&quot; below." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -122,7 +122,7 @@ The syntax for the labeling is described in &quot;Details&quot; below." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/parse_args_list.html
+++ b/docs/reference/parse_args_list.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/parse_param_comment.html
+++ b/docs/reference/parse_param_comment.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/pipe.html
+++ b/docs/reference/pipe.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/plot_nonmem_table_df.html
+++ b/docs/reference/plot_nonmem_table_df.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/print_bbi.html
+++ b/docs/reference/print_bbi.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Check if diagonal index or not — is_diag • rbabylon</title>
+<title>Print methods for rbabylon objects — print_bbi • rbabylon</title>
 
 <!-- favicons -->
 <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
@@ -42,8 +42,12 @@
 
 
 
-<meta property="og:title" content="Check if diagonal index or not — is_diag" />
-<meta property="og:description" content="Private helper to unpack a matrix index string like '(3,3)' is for a diagonal (i.e. if the numbers are the same)" />
+<meta property="og:title" content="Print methods for rbabylon objects — print_bbi" />
+<meta property="og:description" content="The various objects defined by rbabylon have their own print methods to
+allow users to get a quick view of the contents of the object.
+When printing a bbi object in an .Rmd file that is intended to be
+knit, consider setting results = 'asis' in the chunk options. This
+will make for prettier formatting, especially of table outputs." />
 <meta property="og:image" content="https://metrumresearchgroup.github.io/rbabylon/logo.png" />
 <meta name="twitter:card" content="summary" />
 
@@ -137,32 +141,73 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Check if diagonal index or not</h1>
+    <h1>Print methods for rbabylon objects</h1>
     
-    <div class="hidden name"><code>is_diag.Rd</code></div>
+    <div class="hidden name"><code>print_bbi.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    <p>Private helper to unpack a matrix index string like '(3,3)' is for a diagonal (i.e. if the numbers are the same)</p>
+    <p>The various objects defined by <code>rbabylon</code> have their own print methods to
+allow users to get a quick view of the contents of the object.
+<strong>When printing a <code>bbi</code> object in an <code>.Rmd</code> file</strong> that is intended to be
+knit, consider setting <code>results = 'asis'</code> in the chunk options. This
+will make for prettier formatting, especially of table outputs.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>is_diag</span>(<span class='no'>.name</span>)</pre>
+    <pre class="usage"><span class='co'># S3 method for babylon_process</span>
+<span class='fu'><a href='https://rdrr.io/r/base/print.html'>print</a></span>(<span class='no'>x</span>, <span class='no'>...</span>, <span class='kw'>.call_limit</span> <span class='kw'>=</span> <span class='fl'>250</span>)
+
+<span class='co'># S3 method for bbi_nonmem_summary</span>
+<span class='fu'><a href='https://rdrr.io/r/base/print.html'>print</a></span>(<span class='no'>x</span>, <span class='kw'>.digits</span> <span class='kw'>=</span> <span class='fl'>3</span>, <span class='kw'>.fixed</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>.off_diag</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>.nrow</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='no'>...</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
-      <th>.name</th>
-      <td><p>A character scalar containing an index string</p></td>
+      <th>x</th>
+      <td><p>Object to format or print.</p></td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td><p>Other arguments passed on to individual methods.</p></td>
+    </tr>
+    <tr>
+      <th>.call_limit</th>
+      <td><p>Integer scalar for the max number of characters to print before truncating the call string.</p></td>
+    </tr>
+    <tr>
+      <th>.digits</th>
+      <td><p>Number of significant digits to use for parameter table. Defaults to 3.</p></td>
+    </tr>
+    <tr>
+      <th>.fixed</th>
+      <td><p>If <code>FALSE</code>, the default, omits fixed parameters from the parameter table.</p></td>
+    </tr>
+    <tr>
+      <th>.off_diag</th>
+      <td><p>If <code>FALSE</code>, the default, omits off-diagonals of OMEGA and SIGMA matrices from the parameter table.</p></td>
+    </tr>
+    <tr>
+      <th>.nrow</th>
+      <td><p>If <code>NULL</code>, the default, print all rows of the parameter table.
+Otherwise, prints only <code>.nrow</code> rows.</p></td>
     </tr>
     </table>
 
+    <h2 class="hasAnchor" id="functions"><a class="anchor" href="#functions"></a>Functions</h2>
+
+    
+<ul>
+<li><p><code>print.babylon_process</code>: Prints the call made to bbi and whether the process is still running or has finished.</p></li>
+<li><p><code>print.bbi_nonmem_summary</code>: Prints a high level summary of a model from a bbi_nonmem_summary object</p></li>
+</ul>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>
     <ul class="nav nav-pills nav-stacked">
       <li><a href="#arguments">Arguments</a></li>
+      <li><a href="#functions">Functions</a></li>
     </ul>
 
   </div>

--- a/docs/reference/print_bbi_args.html
+++ b/docs/reference/print_bbi_args.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/rbabylon.html
+++ b/docs/reference/rbabylon.html
@@ -84,7 +84,7 @@ designed in a way to be flexible to handle other software." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -92,7 +92,7 @@ designed in a way to be flexible to handle other software." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -127,7 +127,7 @@ designed in a way to be flexible to handle other software." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/read_bbi_path.html
+++ b/docs/reference/read_bbi_path.html
@@ -84,7 +84,7 @@ to a default path if unset." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -92,7 +92,7 @@ to a default path if unset." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -127,7 +127,7 @@ to a default path if unset." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/read_model.html
+++ b/docs/reference/read_model.html
@@ -80,7 +80,7 @@ model_summary(), etc." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -88,7 +88,7 @@ model_summary(), etc." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -123,7 +123,7 @@ model_summary(), etc." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/resolve_nonmem_version.html
+++ b/docs/reference/resolve_nonmem_version.html
@@ -79,7 +79,7 @@ default: true." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -87,7 +87,7 @@ default: true." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -122,7 +122,7 @@ default: true." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/run_log.html
+++ b/docs/reference/run_log.html
@@ -79,7 +79,7 @@ Users can also use add_config() or add_summary() to append additional output abo
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -87,7 +87,7 @@ Users can also use add_config() or add_summary() to append additional output abo
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -122,7 +122,7 @@ Users can also use add_config() or add_summary() to append additional output abo
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/run_log_entry.html
+++ b/docs/reference/run_log_entry.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/safe_based_on.html
+++ b/docs/reference/safe_based_on.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/safe_read_model.html
+++ b/docs/reference/safe_read_model.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/save_model_yaml.html
+++ b/docs/reference/save_model_yaml.html
@@ -78,7 +78,7 @@ the md5 hash after saving." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ the md5 hash after saving." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ the md5 hash after saving." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/sig.html
+++ b/docs/reference/sig.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Check if diagonal index or not — is_diag • rbabylon</title>
+<title>Format digits — sig • rbabylon</title>
 
 <!-- favicons -->
 <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
@@ -42,8 +42,9 @@
 
 
 
-<meta property="og:title" content="Check if diagonal index or not — is_diag" />
-<meta property="og:description" content="Private helper to unpack a matrix index string like '(3,3)' is for a diagonal (i.e. if the numbers are the same)" />
+<meta property="og:title" content="Format digits — sig" />
+<meta property="og:description" content="Simplified version of pmtables::sig() for formatting numbers
+to a specific number of significant digits." />
 <meta property="og:image" content="https://metrumresearchgroup.github.io/rbabylon/logo.png" />
 <meta name="twitter:card" content="summary" />
 
@@ -137,32 +138,41 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Check if diagonal index or not</h1>
+    <h1>Format digits</h1>
     
-    <div class="hidden name"><code>is_diag.Rd</code></div>
+    <div class="hidden name"><code>sig.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    <p>Private helper to unpack a matrix index string like '(3,3)' is for a diagonal (i.e. if the numbers are the same)</p>
+    <p>Simplified version of <code>pmtables::sig()</code> for formatting numbers
+to a specific number of significant digits.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>is_diag</span>(<span class='no'>.name</span>)</pre>
+    <pre class="usage"><span class='fu'>sig</span>(<span class='no'>.x</span>, <span class='no'>.digits</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
-      <th>.name</th>
-      <td><p>A character scalar containing an index string</p></td>
+      <th>x</th>
+      <td><p>numeric, value to manipulate</p></td>
+    </tr>
+    <tr>
+      <th>digits</th>
+      <td><p>numeric, number of significant digits</p></td>
     </tr>
     </table>
 
+    <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
+
+    <p>character vector of formatted values</p>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>
     <ul class="nav nav-pills nav-stacked">
       <li><a href="#arguments">Arguments</a></li>
+      <li><a href="#value">Value</a></li>
     </ul>
 
   </div>

--- a/docs/reference/skip_if_not_drone_or_metworx.html
+++ b/docs/reference/skip_if_not_drone_or_metworx.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Check if diagonal index or not — is_diag • rbabylon</title>
+<title>Skip test if not on Metworx or Drone — skip_if_not_drone_or_metworx • rbabylon</title>
 
 <!-- favicons -->
 <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
@@ -42,8 +42,9 @@
 
 
 
-<meta property="og:title" content="Check if diagonal index or not — is_diag" />
-<meta property="og:description" content="Private helper to unpack a matrix index string like '(3,3)' is for a diagonal (i.e. if the numbers are the same)" />
+<meta property="og:title" content="Skip test if not on Metworx or Drone — skip_if_not_drone_or_metworx" />
+<meta property="og:description" content="Checks for Metworx and Drone environment variables and skips the test if neither are found.
+This is primarily used for tests that require bbi to be installed." />
 <meta property="og:image" content="https://metrumresearchgroup.github.io/rbabylon/logo.png" />
 <meta name="twitter:card" content="summary" />
 
@@ -137,23 +138,25 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Check if diagonal index or not</h1>
+    <h1>Skip test if not on Metworx or Drone</h1>
     
-    <div class="hidden name"><code>is_diag.Rd</code></div>
+    <div class="hidden name"><code>skip_if_not_drone_or_metworx.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    <p>Private helper to unpack a matrix index string like '(3,3)' is for a diagonal (i.e. if the numbers are the same)</p>
+    <p>Checks for Metworx and Drone environment variables and skips the test if neither are found.
+This is primarily used for tests that require <code>bbi</code> to be installed.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>is_diag</span>(<span class='no'>.name</span>)</pre>
+    <pre class="usage"><span class='fu'>skip_if_not_drone_or_metworx</span>(<span class='no'>.test_name</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
-      <th>.name</th>
-      <td><p>A character scalar containing an index string</p></td>
+      <th>.test_name</th>
+      <td><p>Character scalar to identify the test being potentially skipped.
+This is printed in the skip message</p></td>
     </tr>
     </table>
 

--- a/docs/reference/skip_if_over_rate_limit.html
+++ b/docs/reference/skip_if_over_rate_limit.html
@@ -79,7 +79,7 @@ This is appropriate because this package has no interface for passing in a token
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -87,7 +87,7 @@ This is appropriate because this package has no interface for passing in a token
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -122,7 +122,7 @@ This is appropriate because this package has no interface for passing in a token
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/stop_get_fail_msg.html
+++ b/docs/reference/stop_get_fail_msg.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/stop_get_scalar_msg.html
+++ b/docs/reference/stop_get_scalar_msg.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/strict_mode_error.html
+++ b/docs/reference/strict_mode_error.html
@@ -79,7 +79,7 @@ but theoretically advanced users or developers could want to turn them off." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -87,7 +87,7 @@ but theoretically advanced users or developers could want to turn them off." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -122,7 +122,7 @@ but theoretically advanced users or developers could want to turn them off." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/submit_model.html
+++ b/docs/reference/submit_model.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -216,6 +216,9 @@ tool.</p></td>
 <ul>
 <li><p><code>bbi_nonmem_model</code>: Takes a <code>bbi_nonmem_model</code> object.</p></li>
 </ul>
+    <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
+
+    <div class='dont-index'><p><code><a href='submit_models.html'>submit_models()</a></code></p></div>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
@@ -223,6 +226,7 @@ tool.</p></td>
     <ul class="nav nav-pills nav-stacked">
       <li><a href="#arguments">Arguments</a></li>
       <li><a href="#methods-by-class-">Methods (by class)</a></li>
+      <li><a href="#see-also">See also</a></li>
     </ul>
 
   </div>

--- a/docs/reference/submit_models.html
+++ b/docs/reference/submit_models.html
@@ -78,7 +78,7 @@ few external calls as possible (see &quot;Details&quot;)." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ few external calls as possible (see &quot;Details&quot;)." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ few external calls as possible (see &quot;Details&quot;)." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -224,6 +224,9 @@ model YAML, or specified globally in <code>babylon.yaml</code>.</p>
 <ul>
 <li><p><code>list</code>: Takes a list of <code>bbi_nonmem_model</code> objects.</p></li>
 </ul>
+    <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
+
+    <div class='dont-index'><p><code><a href='submit_model.html'>submit_model()</a></code></p></div>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
@@ -232,6 +235,7 @@ model YAML, or specified globally in <code>babylon.yaml</code>.</p>
       <li><a href="#arguments">Arguments</a></li>
       <li><a href="#details">Details</a></li>
       <li><a href="#methods-by-class-">Methods (by class)</a></li>
+      <li><a href="#see-also">See also</a></li>
     </ul>
 
   </div>

--- a/docs/reference/submit_nonmem_model.html
+++ b/docs/reference/submit_nonmem_model.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/submit_nonmem_models.html
+++ b/docs/reference/submit_nonmem_models.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/summary_log.html
+++ b/docs/reference/summary_log.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -173,7 +173,8 @@
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
-    <p>An object of class <code>bbi_summary_log_df</code>, which includes the fields described below.</p>
+    <p>An object of class <code>bbi_summary_log_df</code>, which includes the fields described below. If <em>all</em> model summaries
+fail, the returned tibble will only contain the <code>absolute_model_path</code>, <code>run</code>, and <code>error_msg</code> columns.</p>
 <p><code>summary_log()</code> creates a new tibble with one row per model
 found in <code>.base_dir</code> (and subdirectories, if <code>.recurse = TRUE</code>).</p>
 <p><code>add_summary()</code> adds these fields to the tibble passed to <code>.log_df</code>.</p>

--- a/docs/reference/summary_log_impl.html
+++ b/docs/reference/summary_log_impl.html
@@ -78,7 +78,7 @@ This is called by both summary_log() and add_summary()." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ This is called by both summary_log() and add_summary()." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ This is called by both summary_log() and add_summary()." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/suppressSpecificWarning.html
+++ b/docs/reference/suppressSpecificWarning.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/use_bbi.html
+++ b/docs/reference/use_bbi.html
@@ -79,7 +79,7 @@ If used in an interactive session, will open an installation menu confirming the
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -87,7 +87,7 @@ If used in an interactive session, will open an installation menu confirming the
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -122,7 +122,7 @@ If used in an interactive session, will open an installation menu confirming the
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/verify_model_yaml_integrity.html
+++ b/docs/reference/verify_model_yaml_integrity.html
@@ -78,7 +78,7 @@ to keep track of any changes made to the YAML that are not reflected in the obje
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -86,7 +86,7 @@ to keep track of any changes made to the YAML that are not reflected in the obje
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -121,7 +121,7 @@ to keep track of any changes made to the YAML that are not reflected in the obje
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/version_message.html
+++ b/docs/reference/version_message.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">rbabylon</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.10.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.11.0</span>
       </span>
     </div>
 
@@ -85,7 +85,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -120,7 +120,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/metrumresearchgroup/rbabylon">
-    <span class="fa fa-github fa-lg"></span>
+    <span class="fas fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -73,6 +73,9 @@
     <loc>https://metrumresearchgroup.github.io/rbabylon/reference/check_model_object_list.html</loc>
   </url>
   <url>
+    <loc>https://metrumresearchgroup.github.io/rbabylon/reference/check_nonmem_table_bbi.html</loc>
+  </url>
+  <url>
     <loc>https://metrumresearchgroup.github.io/rbabylon/reference/check_nonmem_table_output.html</loc>
   </url>
   <url>
@@ -148,6 +151,9 @@
     <loc>https://metrumresearchgroup.github.io/rbabylon/reference/get_path_from_object.html</loc>
   </url>
   <url>
+    <loc>https://metrumresearchgroup.github.io/rbabylon/reference/highlight_cell.html</loc>
+  </url>
+  <url>
     <loc>https://metrumresearchgroup.github.io/rbabylon/reference/install_menu.html</loc>
   </url>
   <url>
@@ -220,6 +226,9 @@
     <loc>https://metrumresearchgroup.github.io/rbabylon/reference/plot_nonmem_table_df.html</loc>
   </url>
   <url>
+    <loc>https://metrumresearchgroup.github.io/rbabylon/reference/print_bbi.html</loc>
+  </url>
+  <url>
     <loc>https://metrumresearchgroup.github.io/rbabylon/reference/print_bbi_args.html</loc>
   </url>
   <url>
@@ -248,6 +257,12 @@
   </url>
   <url>
     <loc>https://metrumresearchgroup.github.io/rbabylon/reference/save_model_yaml.html</loc>
+  </url>
+  <url>
+    <loc>https://metrumresearchgroup.github.io/rbabylon/reference/sig.html</loc>
+  </url>
+  <url>
+    <loc>https://metrumresearchgroup.github.io/rbabylon/reference/skip_if_not_drone_or_metworx.html</loc>
   </url>
   <url>
     <loc>https://metrumresearchgroup.github.io/rbabylon/reference/skip_if_over_rate_limit.html</loc>


### PR DESCRIPTION
# rbabylon 0.11.0 release

Many of the changes in this release are _not_ user-facing. Specifically there were some changes in our dependencies that forced us to change many of our tests (for example #286 and #287). 

## New features and changes

* Added print methods for `bbi_nonmem_summary` and `babylon_process` objects. The `bbi_nonmem_summary` object should print nicely in the console, and also look good in `.Rmd` chunks with the option `results = 'asis'`. (#298 and #294)

* The `bbi_nonmem_summary` object now contains the `absolute_model_path` and we have added the following methods to work on that object (these previously only worked on `bbi_nonmem_model` objects): `get_model_id()`, `get_model_path()`, `get_output_dir()`, `get_yaml_path()`, `check_grd()`, `check_ext()`. (#297)

* For developers, there are now scripts in `data-raw` which regenerate the test reference files and re-run the test models. All test references and example files have now been consolidated in `inst` as well. Users will see these files in `extdata`, `model`, and `test-refs` when the package is installed. (#289)

* Also for developers, we are now using `pkgr` and `renv` to isolate dependencies when developing. The `README` has been updated with instructions for how to use this when developing. (#276)

## Bug fixes

* Previously `replace_model_field()`, which is called under the hood by `replace_tag()` and `replace_note()` did _not_ modify the YAML file as it should have. That has been fixed. (#281)

* Previously the `add_summary()` function would error if all the model summaries errored. Now it will return, passing through the model summary errors to the tibble, as it should. (#282)
