### PR TITLE
adding mrgvalidate-style Test Id's

### DIFF
--- a/tests/testthat/test-bbr.R
+++ b/tests/testthat/test-bbr.R
@@ -3,7 +3,7 @@ context("bbr exec functions")
 # constants
 BBI_EXE_PATH <- read_bbi_path()
 
-test_that("check_status_code works as expected", {
+test_that("check_status_code works as expected [BBR-BBR-001]", {
   # nothing happens on status 0
   expect_equal(check_status_code(0, "stdout...", c("arg1", "arg2")), NULL)
 
@@ -13,7 +13,7 @@ test_that("check_status_code works as expected", {
   expect_error(check_status_code(225, "stdout...", c("arg1", "arg2")))
 })
 
-test_that("bbi_dry_run() correctly returns object", {
+test_that("bbi_dry_run() correctly returns object [BBR-BBR-002]", {
   PROC_CLASS_LIST <- c("bbi_process", "list")
   cmd_args <- c("naw", "dawg")
   dir <- "fake/dir"
@@ -33,7 +33,7 @@ test_that("bbi_dry_run() correctly returns object", {
 
 skip_if_not_drone_or_metworx("bbi_init")
 
-test_that("check_bbi_exe() correctly errors or finds paths", {
+test_that("check_bbi_exe() correctly errors or finds paths [BBR-BBR-003]", {
   FAKE_BBI_PATH <- "/tmp/fake/bbi"
 
   # should fail because path doesn't exist
@@ -43,7 +43,7 @@ test_that("check_bbi_exe() correctly errors or finds paths", {
   expect_invisible(check_bbi_exe(BBI_EXE_PATH))
 })
 
-test_that("check_bbi_exe() errors on too low version", {
+test_that("check_bbi_exe() errors on too low version [BBR-BBR-004]", {
   skip_if_over_rate_limit()
   skip_if(getOption("bbr.DEV_no_min_version"))
 
@@ -55,7 +55,7 @@ test_that("check_bbi_exe() errors on too low version", {
   })
 })
 
-test_that("bbi_init creates bbi.yaml", {
+test_that("bbi_init creates bbi.yaml [BBR-BBR-005]", {
   # create yaml
 
   withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
@@ -68,11 +68,11 @@ test_that("bbi_init creates bbi.yaml", {
   expect_true("bbi_binary" %in% names(bbi_yaml))
 })
 
-test_that("bbi_init errors with non-existent .dir", {
+test_that("bbi_init errors with non-existent .dir [BBR-BBR-006]", {
   expect_error(bbi_init("naw", "."), regexp = "Cannot find.+naw")
 })
 
-test_that("bbi_init errors with invalid .nonmem_version", {
+test_that("bbi_init errors with invalid .nonmem_version [BBR-BBR-007]", {
   # fails if don't specify anything
   expect_error(bbi_init(".", "."), regexp = "Must specify a `.nonmem_version`")
 
@@ -83,7 +83,7 @@ test_that("bbi_init errors with invalid .nonmem_version", {
   })
 })
 
-test_that("bbi_init passes .bbi_args", {
+test_that("bbi_init passes .bbi_args [BBR-BBR-008]", {
   # create yaml
 
   withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {

--- a/tests/testthat/test-check-up-to-date.R
+++ b/tests/testthat/test-check-up-to-date.R
@@ -5,11 +5,11 @@ ALL_BAD <- c(model = FALSE, data = FALSE)
 MODEL_BAD <- c(model = FALSE, data = TRUE)
 DATA_BAD <- c(model = TRUE, data = FALSE)
 
-test_that("check_up_to_date.bbi_nonmem_model() happy path", {
+test_that("check_up_to_date.bbi_nonmem_model() happy path [BBR-CUTD-001]", {
   expect_equal(check_up_to_date(MOD1), ALL_GOOD)
 })
 
-test_that("check_up_to_date.bbi_nonmem_model() with mismatched model", {
+test_that("check_up_to_date.bbi_nonmem_model() with mismatched model [BBR-CUTD-002]", {
   perturb_file(CTL_TEST_FILE)
   expect_message(
     res <- check_up_to_date(MOD1),
@@ -18,7 +18,7 @@ test_that("check_up_to_date.bbi_nonmem_model() with mismatched model", {
   expect_equal(res, MODEL_BAD)
 })
 
-test_that("check_up_to_date.bbi_nonmem_model() with mismatched data", {
+test_that("check_up_to_date.bbi_nonmem_model() with mismatched data [BBR-CUTD-003]", {
   perturb_file(get_data_path(MOD1))
   expect_message(
     res <- check_up_to_date(MOD1),
@@ -27,7 +27,7 @@ test_that("check_up_to_date.bbi_nonmem_model() with mismatched data", {
   expect_equal(res, DATA_BAD)
 })
 
-test_that("check_up_to_date.bbi_nonmem_model() with missing data", {
+test_that("check_up_to_date.bbi_nonmem_model() with missing data [BBR-CUTD-004]", {
   temp_mod_path <- create_temp_model()
   new_mod <- read_model(temp_mod_path)
   fs::dir_copy(get_output_dir(MOD1), get_output_dir(new_mod, .check_exists = F))
@@ -39,7 +39,7 @@ test_that("check_up_to_date.bbi_nonmem_model() with missing data", {
   expect_equal(res, ALL_BAD)
 })
 
-test_that("check_up_to_date.bbi_nonmem_model() with mismatched both", {
+test_that("check_up_to_date.bbi_nonmem_model() with mismatched both [BBR-CUTD-005]", {
   perturb_file(CTL_TEST_FILE)
   perturb_file(get_data_path(MOD1))
   expect_message(
@@ -49,7 +49,7 @@ test_that("check_up_to_date.bbi_nonmem_model() with mismatched both", {
   expect_equal(res, ALL_BAD)
 })
 
-test_that("check_up_to_date.bbi_nonmem_summary() with mismatched model", {
+test_that("check_up_to_date.bbi_nonmem_summary() with mismatched model [BBR-CUTD-006]", {
   skip_if_not_drone_or_metworx("check_up_to_date.bbi_nonmem_summary")
   perturb_file(CTL_TEST_FILE)
   expect_message(
@@ -60,7 +60,7 @@ test_that("check_up_to_date.bbi_nonmem_summary() with mismatched model", {
 })
 
 
-test_that("check_up_to_date.bbi_log_df() works as expected", {
+test_that("check_up_to_date.bbi_log_df() works as expected [BBR-CUTD-007]", {
   # create models for the run log
   create_all_models()
   copy_all_output_dirs()

--- a/tests/testthat/test-collapse-to-string.R
+++ b/tests/testthat/test-collapse-to-string.R
@@ -6,7 +6,7 @@ create_rlg_models()
 # teardown
 withr::defer(cleanup())
 
-test_that("collapse_to_string() works correctly", {
+test_that("collapse_to_string() works correctly [BBR-CTS-001]", {
   # add a note to collapse
   mod2 <- read_model(file.path(MODEL_DIR, 2)) %>% add_notes(NEW_NOTES)
   on.exit(replace_all_notes(mod2, NULL))
@@ -37,7 +37,7 @@ test_that("collapse_to_string() works correctly", {
   )
 })
 
-test_that("collapse_to_string() warns correctly", {
+test_that("collapse_to_string() warns correctly [BBR-CTS-002]", {
   log_df <- run_log(MODEL_DIR) %>%
     collapse_to_string({{YAML_TAGS}})
 
@@ -47,7 +47,7 @@ test_that("collapse_to_string() warns correctly", {
   )
 })
 
-test_that("collapse_to_string() errors correctly", {
+test_that("collapse_to_string() errors correctly [BBR-CTS-003]", {
   log_df <- run_log(MODEL_DIR) %>%
     collapse_to_string({{YAML_TAGS}})
 
@@ -57,7 +57,7 @@ test_that("collapse_to_string() errors correctly", {
   )
 })
 
-test_that("collapse_to_string() renders dput correctly", {
+test_that("collapse_to_string() renders dput correctly [BBR-CTS-004]", {
   log_df <- run_log(MODEL_DIR)
   ref_args <- purrr::map_chr(
     log_df[[YAML_BBI_ARGS]],
@@ -70,7 +70,7 @@ test_that("collapse_to_string() renders dput correctly", {
   expect_identical(ref_args, log_df[[YAML_BBI_ARGS]])
 })
 
-test_that("collapse_to_string() renders dput for tibbles", {
+test_that("collapse_to_string() renders dput for tibbles [BBR-CTS-005]", {
   nums <- seq_len(3)
   df <- tibble::tibble(
     row_num   = nums,
@@ -91,7 +91,7 @@ test_that("collapse_to_string() renders dput for tibbles", {
   expect_identical(ref_tib, df$tibby)
 })
 
-test_that("add_tags() converts lists upstream of collapse_to_string()", {
+test_that("add_tags() converts lists upstream of collapse_to_string() [BBR-CTS-006]", {
   mod2 <- read_model(file.path(MODEL_DIR, 2))
   tags_old <- mod2[[YAML_TAGS]]
   # Note: The shape of the value here matters: it needs to be

--- a/tests/testthat/test-config-log.R
+++ b/tests/testthat/test-config-log.R
@@ -67,14 +67,14 @@ copy_all_output_dirs()
 # teardown
 withr::defer(cleanup())
 
-test_that("config_log() returns NULL and warns when no YAML found", {
+test_that("config_log() returns NULL and warns when no YAML found [BBR-CGLG-001]", {
   log_df <- expect_warning(config_log("."), regexp = "Found no valid model YAML files in")
   expect_true(inherits(log_df, "tbl"))
   expect_equal(nrow(log_df), 0)
   expect_equal(ncol(log_df), 0)
 })
 
-test_that("config_log() works correctly with nested dirs", {
+test_that("config_log() works correctly with nested dirs [BBR-CGLG-002]", {
   log_df <- config_log(MODEL_DIR)
   check_config_ref(
     log_df,
@@ -84,7 +84,7 @@ test_that("config_log() works correctly with nested dirs", {
   )
 })
 
-test_that("config_log(.recurse = FALSE) works", {
+test_that("config_log(.recurse = FALSE) works [BBR-CGLG-003]", {
   log_df <- config_log(MODEL_DIR, .recurse = FALSE)
   check_config_ref(
     log_df,
@@ -94,29 +94,29 @@ test_that("config_log(.recurse = FALSE) works", {
   )
 })
 
-test_that("config_log() reflects model mismatch", {
+test_that("config_log() reflects model mismatch [BBR-CGLG-004]", {
   perturb_file(CTL_TEST_FILE)
   log_df <- config_log(MODEL_DIR)
   expect_equal(log_df[["model_has_changed"]][1], TRUE)
 })
 
-test_that("config_log() reflects data mismatch", {
+test_that("config_log() reflects data mismatch [BBR-CGLG-005]", {
   perturb_file(system.file("extdata", "acop.csv", package = "bbr"))
   log_df <- config_log(MODEL_DIR)
   expect_equal(log_df[["data_has_changed"]][1], TRUE)
 })
 
-test_that("config_log() includes bbi version", {
+test_that("config_log() includes bbi version [BBR-CGLG-006]", {
   log_df <- config_log(MODEL_DIR)
   expect_equal(log_df[["bbi_version"]][1], expected_bbi_version)
 })
 
-test_that("config_log() includes NONMEM version", {
+test_that("config_log() includes NONMEM version [BBR-CGLG-007]", {
   log_df <- config_log(MODEL_DIR)
   expect_equal(log_df[["nm_version"]][1], expected_nonmem_version)
 })
 
-test_that("add_config() works correctly", {
+test_that("add_config() works correctly [BBR-CGLG-008]", {
   log_df <- run_log(MODEL_DIR) %>% add_config()
   check_config_ref(
     log_df,
@@ -126,7 +126,7 @@ test_that("add_config() works correctly", {
   )
 })
 
-test_that("add_config() has correct columns", {
+test_that("add_config() has correct columns [BBR-CGLG-009]", {
   conf_df <- config_log(MODEL_DIR)
   log_df <- run_log(MODEL_DIR)
   add_df <- log_df %>% add_config()
@@ -144,7 +144,7 @@ fs::file_delete(file.path(NEW_MOD3, "bbi_config.json"))
 fs::file_delete(file.path(LEVEL2_MOD, "bbi_config.json"))
 missing_idx <- c(3L, 4L)
 
-test_that("add_config() works correctly with missing json", {
+test_that("add_config() works correctly with missing json [BBR-CGLG-010]", {
   log_df <- expect_warning(run_log(MODEL_DIR) %>% add_config(), regexp = "Found only 2 bbi_config.json files for 4 models")
   expect_equal(nrow(log_df), RUN_LOG_ROWS+1)
   expect_equal(ncol(log_df), RUN_LOG_COLS+CONFIG_COLS-2)
@@ -184,7 +184,7 @@ test_that("add_config() works correctly with missing json", {
 fs::dir_delete(NEW_MOD3)
 fs::dir_delete(LEVEL2_MOD)
 
-test_that("config_log() works with missing output dirs", {
+test_that("config_log() works with missing output dirs [BBR-CGLG-011]", {
   log_df <- expect_warning(
     config_log(MODEL_DIR),
     regexp = "Found only 2 bbi_config.json files for 4 models"
@@ -195,7 +195,7 @@ test_that("config_log() works with missing output dirs", {
   expect_false(any(duplicated(log_df[[ABS_MOD_PATH]])))
 })
 
-test_that("config_log() works with no json found", {
+test_that("config_log() works with no json found [BBR-CGLG-012]", {
 
   expect_warning({
     log_df <- config_log(LEVEL2_DIR)
@@ -205,7 +205,7 @@ test_that("config_log() works with no json found", {
   expect_equal(names(log_df), c(ABS_MOD_PATH, RUN_ID_COL))
 })
 
-test_that("add_config() works no json found", {
+test_that("add_config() works no json found [BBR-CGLG-013]", {
 
   expect_warning({
     log_df <- run_log(LEVEL2_DIR) %>% add_config()

--- a/tests/testthat/test-copy-model-from.R
+++ b/tests/testthat/test-copy-model-from.R
@@ -6,7 +6,7 @@ context("Copying model objects")
 
 cleanup()
 
-test_that("copy_from_model creates accurate copy", {
+test_that("copy_from_model creates accurate copy [BBR-CMF-001]", {
   on.exit({ cleanup() })
 
   # run copy_model_from
@@ -33,7 +33,7 @@ test_that("copy_from_model creates accurate copy", {
 })
 
 
-test_that("copy_from_model options work", {
+test_that("copy_from_model options work [BBR-CMF-002]", {
   on.exit({ cleanup() })
 
   # run copy_model_from
@@ -63,7 +63,7 @@ test_that("copy_from_model options work", {
   )
 })
 
-test_that("copy_from_model.bbi_nonmem_model works with numeric input", {
+test_that("copy_from_model.bbi_nonmem_model works with numeric input [BBR-CMF-003]", {
   on.exit({ cleanup() })
 
   # check that the model is not there already
@@ -83,7 +83,7 @@ test_that("copy_from_model.bbi_nonmem_model works with numeric input", {
 })
 
 
-test_that("copy_from_model .overwrite=TRUE works", {
+test_that("copy_from_model .overwrite=TRUE works [BBR-CMF-004]", {
   on.exit({ cleanup() })
 
   # set up model object
@@ -108,7 +108,7 @@ test_that("copy_from_model .overwrite=TRUE works", {
   expect_true(grepl(new_desc_pattern, new_mod_str))
 })
 
-test_that("copy_from_model .overwrite=FALSE works", {
+test_that("copy_from_model .overwrite=FALSE works [BBR-CMF-005]", {
   on.exit({ cleanup() })
 
   # set up model object
@@ -136,7 +136,7 @@ test_that("copy_from_model .overwrite=FALSE works", {
   expect_false(grepl(new_desc_pattern, new_mod_str))
 })
 
-test_that("copy_model_from() supports `.new_model` containing a period", {
+test_that("copy_model_from() supports `.new_model` containing a period [BBR-CMF-006]", {
   temp_mod_path <- create_temp_model()
   temp_mod <- read_model(temp_mod_path)
 

--- a/tests/testthat/test-cov-cor.R
+++ b/tests/testthat/test-cov-cor.R
@@ -10,7 +10,7 @@ check_mat_dim <- function(.mat, .theta_dim, .dim) {
 
 withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
 
-  test_that("cov_cor() works basic model", {
+  test_that("cov_cor() works basic model [BBR-CVCR-001]", {
     .c <- cov_cor(MOD1)
     check_mat_dim(.c, 5, 9)
 
@@ -35,7 +35,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
 
   })
 
-  test_that("cov_cor() works with two estimation methods", {
+  test_that("cov_cor() works with two estimation methods [BBR-CVCR-002]", {
     .c <- file.path(MODEL_DIR_X, "example2_saemimp") %>%
       read_model() %>%
       cov_cor()
@@ -44,7 +44,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     # TODO: add a test that it's actually the second estimation method
   })
 
-  test_that("cov_cor() warns with correlations over threshold", {
+  test_that("cov_cor() warns with correlations over threshold [BBR-CVCR-003]", {
     expect_warning({
       .c <- cov_cor(MOD1, .threshold = 0.95)
     }, regexp = "correlations above specified threshold")
@@ -52,7 +52,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     check_mat_dim(.c, 5, 9)
   })
 
-  test_that("cov_cor() errors if no .cov file", {
+  test_that("cov_cor() errors if no .cov file [BBR-CVCR-004]", {
     expect_error({
       .c <- file.path(MODEL_DIR_X, "acop-fake-bayes") %>%
         read_model() %>%
@@ -60,7 +60,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     }, regexp = "[Nn]o file present.*\\.cov")
   })
 
-  test_that("check_cor_threshold() works correctly", {
+  test_that("check_cor_threshold() works correctly [BBR-CVCR-005]", {
     .c <- cov_cor(MOD1)
     check_mat_dim(.c, 5, 9)
 

--- a/tests/testthat/test-get-based-on.R
+++ b/tests/testthat/test-get-based-on.R
@@ -1,6 +1,6 @@
 context("Extract model paths from based_on fields")
 
-test_that("get_based_on works happy path model object" , {
+test_that("get_based_on works happy path model object [BBR-GBO-001]" , {
   on.exit({ cleanup() })
 
   # create copy
@@ -9,7 +9,7 @@ test_that("get_based_on works happy path model object" , {
   expect_identical(get_based_on(mod2), MOD1_ABS_PATH)
 })
 
-test_that("get_based_on works happy path character" , {
+test_that("get_based_on works happy path character [BBR-GBO-002]" , {
   on.exit({ cleanup() })
 
   # create copy
@@ -18,11 +18,11 @@ test_that("get_based_on works happy path character" , {
   expect_identical(get_based_on(NEW_MOD2), MOD1_ABS_PATH)
 })
 
-test_that("get_based_on.character() fails with vector", {
+test_that("get_based_on.character() fails with vector [BBR-GBO-003]", {
   expect_error(get_based_on(c("naw", "dawg")), regexp = "only scalar values are permitted")
 })
 
-test_that("get_based_on works happy path run_log tibble" , {
+test_that("get_based_on works happy path run_log tibble [BBR-GBO-004]" , {
   on.exit({ cleanup() })
   create_all_models()
 
@@ -42,7 +42,7 @@ test_that("get_based_on works happy path run_log tibble" , {
   )
 })
 
-test_that("get_based_on constructs ancestry manually" , {
+test_that("get_based_on constructs ancestry manually [BBR-GBO-005]" , {
   on.exit({ cleanup() })
   create_all_models()
 
@@ -68,7 +68,7 @@ test_that("get_based_on constructs ancestry manually" , {
   }
 })
 
-test_that("get_based_on .check_exists=TRUE errors if model is gone" , {
+test_that("get_based_on .check_exists=TRUE errors if model is gone [BBR-GBO-006]" , {
   on.exit({ cleanup() })
   create_all_models()
 
@@ -85,7 +85,7 @@ test_that("get_based_on .check_exists=TRUE errors if model is gone" , {
   expect_error(get_based_on(mod3, .check_exists = TRUE), regexp = "but cannot find .yaml")
 })
 
-test_that("get_based_on() behaves correctly on missing keys", {
+test_that("get_based_on() behaves correctly on missing keys [BBR-GBO-007]", {
   # missing YAML_BASED_ON
   .test_list <- list()
   .test_list[[ABS_MOD_PATH]] <- "/fake/path"
@@ -100,7 +100,7 @@ test_that("get_based_on() behaves correctly on missing keys", {
 })
 
 
-test_that("get_model_ancestry works happy path model object" , {
+test_that("get_model_ancestry works happy path model object [BBR-GBO-008]" , {
   on.exit({ cleanup() })
   create_all_models()
 
@@ -119,7 +119,7 @@ test_that("get_model_ancestry works happy path model object" , {
   expect_equal(2, log_df %>% filter(absolute_model_path %in% get_model_ancestry(mod4)) %>% nrow())
 })
 
-test_that("get_model_ancestry works happy path character" , {
+test_that("get_model_ancestry works happy path character [BBR-GBO-009]" , {
   on.exit({ cleanup() })
   create_all_models()
 
@@ -133,11 +133,11 @@ test_that("get_model_ancestry works happy path character" , {
   )
 })
 
-test_that("get_model_ancestry.character() fails with vector", {
+test_that("get_model_ancestry.character() fails with vector [BBR-GBO-010]", {
   expect_error(get_model_ancestry(c("naw", "dawg")), regexp = "only scalar values are permitted")
 })
 
-test_that("get_model_ancestry works happy path run_log tibble" , {
+test_that("get_model_ancestry works happy path run_log tibble [BBR-GBO-011]" , {
   on.exit({ cleanup() })
   create_all_models()
 
@@ -157,7 +157,7 @@ test_that("get_model_ancestry works happy path run_log tibble" , {
   )
 })
 
-test_that("get_model_ancestry errors if model is gone" , {
+test_that("get_model_ancestry errors if model is gone [BBR-GBO-012]" , {
   on.exit({ cleanup() })
   create_all_models()
 
@@ -169,7 +169,7 @@ test_that("get_model_ancestry errors if model is gone" , {
   expect_error(get_model_ancestry(mod4), regexp = "Cannot load model object from path")
 })
 
-test_that("get_model_ancestry works on run_log tibble with more complicated ancestry" , {
+test_that("get_model_ancestry works on run_log tibble with more complicated ancestry [BBR-GBO-013]" , {
   on.exit({ cleanup() })
   create_all_models()
 

--- a/tests/testthat/test-get-path-from-object.R
+++ b/tests/testthat/test-get-path-from-object.R
@@ -8,34 +8,34 @@ context("Build paths from model object")
 # get_path_from_object
 #######################
 
-test_that("get_model_path() builds the right path", {
+test_that("get_model_path() builds the right path [BBR-GPFO-001]", {
   expect_identical(get_model_path(MOD1), normalizePath(CTL_TEST_FILE))
 })
 
-test_that("get_output_dir() builds the right path", {
+test_that("get_output_dir() builds the right path [BBR-GPFO-002]", {
   expect_identical(get_output_dir(MOD1), normalizePath(OUTPUT_DIR))
 })
 
-test_that("get_yaml_path() builds the right path", {
+test_that("get_yaml_path() builds the right path [BBR-GPFO-003]", {
   expect_identical(get_yaml_path(MOD1), normalizePath(YAML_TEST_FILE))
 })
 
-test_that("get_model_path() builds the right path from summary object", {
+test_that("get_model_path() builds the right path from summary object [BBR-GPFO-004]", {
   skip_if_not_drone_or_metworx("get_model_path.bbi_nonmem_summary")
   expect_identical(get_model_path(SUM1), normalizePath(CTL_TEST_FILE))
 })
 
-test_that("get_output_dir() builds the right path from summary object", {
+test_that("get_output_dir() builds the right path from summary object [BBR-GPFO-005]", {
   skip_if_not_drone_or_metworx("get_output_dir.bbi_nonmem_summary")
   expect_identical(get_output_dir(SUM1), normalizePath(OUTPUT_DIR))
 })
 
-test_that("get_yaml_path() builds the right path from summary object", {
+test_that("get_yaml_path() builds the right path from summary object [BBR-GPFO-006]", {
   skip_if_not_drone_or_metworx("get_yaml_path.bbi_nonmem_summary")
   expect_identical(get_yaml_path(SUM1), normalizePath(YAML_TEST_FILE))
 })
 
-test_that("get_model_path() works with bbi_*_log_df", {
+test_that("get_model_path() works with bbi_*_log_df [BBR-GPFO-007]", {
   create_all_models()
   on.exit(cleanup())
 
@@ -45,28 +45,28 @@ test_that("get_model_path() works with bbi_*_log_df", {
   expect_identical(ref_mod_paths, res_mod_paths)
 })
 
-test_that("get_output_dir() works with bbi_*_log_df", {
+test_that("get_output_dir() works with bbi_*_log_df [BBR-GPFO-008]", {
   expect_identical(get_output_dir(run_log(MODEL_DIR)), normalizePath(OUTPUT_DIR))
 })
 
-test_that("get_yaml_path() works with bbi_*_log_df", {
+test_that("get_yaml_path() works with bbi_*_log_df [BBR-GPFO-009]", {
   expect_identical(get_yaml_path(run_log(MODEL_DIR)), normalizePath(YAML_TEST_FILE))
 })
 
-test_that("get_model_path() finds .mod path", {
+test_that("get_model_path() finds .mod path [BBR-GPFO-010]", {
   temp_mod_path <- create_temp_model(mod_ext = "mod")
   temp_mod <- mod_ext(temp_mod_path)
   mod <- read_model(temp_mod_path)
   expect_identical(get_model_path(mod), temp_mod)
 })
 
-test_that("get_model_path() errors with both .ctl and .mod paths", {
+test_that("get_model_path() errors with both .ctl and .mod paths [BBR-GPFO-011]", {
   on.exit(fs::file_delete(MOD_TEST_FILE))
   fs::file_copy(CTL_TEST_FILE, MOD_TEST_FILE)
   expect_error(get_model_path(MOD1), "Both.+files found")
 })
 
-test_that("get_model_path() works no paths found", {
+test_that("get_model_path() works no paths found [BBR-GPFO-012]", {
   temp_mod_path <- create_temp_model(delete_mod = FALSE)
   mod <- read_model(temp_mod_path)
   # save path to model file and then delete the file
@@ -91,28 +91,28 @@ test_that("get_model_path() works no paths found", {
   LST_TEST_FILE
 )
 for (.tc in .test_cases) {
-  test_that(glue::glue("get_model_id parses {.tc}"), {
+  test_that(glue::glue("get_model_id parses {.tc} [BBR-GPFO-013]"), {
     expect_identical(get_model_id(.tc), MOD_ID)
   })
 }
 
-test_that("get_model_id parses model object", {
+test_that("get_model_id parses model object [BBR-GPFO-014]", {
   expect_identical(get_model_id(MOD1), MOD_ID)
 })
 
-test_that("get_model_id parses summary object", {
+test_that("get_model_id parses summary object [BBR-GPFO-015]", {
   skip_if_not_drone_or_metworx("get_model_id.bbi_nonmem_summary")
   expect_identical(get_model_id(SUM1), MOD_ID)
 })
 
 
-test_that("get_data_path parses model object", {
+test_that("get_data_path parses model object [BBR-GPFO-016]", {
   res_data_path <- get_data_path(MOD1)
   expect_identical(res_data_path, DATA_TEST_FILE)
   expect_identical(readLines(res_data_path, n = 1), DATA_TEST_FIRST_LINE)
 })
 
-test_that("get_data_path parses summary object", {
+test_that("get_data_path parses summary object [BBR-GPFO-017]", {
   skip_if_not_drone_or_metworx("get_data_path.bbi_nonmem_summary")
   res_data_path <- get_data_path(SUM1)
   expect_identical(res_data_path, DATA_TEST_FILE)
@@ -126,19 +126,19 @@ test_that("get_data_path parses summary object", {
   EXT_TEST_FILE
 )
 for (.tc in .test_cases) {
-  test_that(glue::glue("build_path_from_model returns correct {tools::file_ext(.tc)} from model object"), {
+  test_that(glue::glue("build_path_from_model returns correct {tools::file_ext(.tc)} from model object [BBR-GPFO-018]"), {
     expect_identical(build_path_from_model(MOD1, paste0(".", tools::file_ext(.tc))),
                      normalizePath(.tc))
   })
 
-  test_that(glue::glue("build_path_from_model returns correct {tools::file_ext(.tc)} from summary object"), {
+  test_that(glue::glue("build_path_from_model returns correct {tools::file_ext(.tc)} from summary object [BBR-GPFO-019]"), {
     skip_if_not_drone_or_metworx(glue::glue("build_path_from_model.bbi_nonmem_summary {tools::file_ext(.tc)}"))
     expect_identical(build_path_from_model(SUM1, paste0(".", tools::file_ext(.tc))),
                      normalizePath(.tc))
   })
 }
 
-test_that("build_path_from_model works with period in extension", {
+test_that("build_path_from_model works with period in extension [BBR-GPFO-020]", {
   expect_identical(
     build_path_from_model(MOD1, "par.tab"),
     as.character(glue::glue("{MOD1_ABS_PATH}/{MOD_ID}par.tab"))
@@ -146,13 +146,13 @@ test_that("build_path_from_model works with period in extension", {
 })
 
 
-test_that("is_valid_nonmem_extension() works", {
+test_that("is_valid_nonmem_extension() works [BBR-GPFO-021]", {
   expect_true(is_valid_nonmem_extension(MOD_TEST_FILE))
   expect_true(is_valid_nonmem_extension(CTL_TEST_FILE))
   expect_false(is_valid_nonmem_extension(YAML_TEST_FILE))
 })
 
-test_that("is_valid_yaml_extension() works", {
+test_that("is_valid_yaml_extension() works [BBR-GPFO-022]", {
   expect_true(is_valid_yaml_extension(YAML_TEST_FILE))
   expect_true(is_valid_yaml_extension("naw.yaml"))
   expect_false(is_valid_yaml_extension(MOD_TEST_FILE))
@@ -164,7 +164,7 @@ test_that("is_valid_yaml_extension() works", {
   MOD_TEST_FILE
 )
 for (.tc in .test_cases) {
-  test_that(glue::glue("ctl_ext parses {.tc}"), {
+  test_that(glue::glue("ctl_ext parses {.tc}  [BBR-GPFO-023]"), {
     expect_identical(ctl_ext(.tc), CTL_TEST_FILE)
   })
 }
@@ -175,7 +175,7 @@ for (.tc in .test_cases) {
   CTL_TEST_FILE
 )
 for (.tc in .test_cases) {
-  test_that(glue::glue("mod_ext parses {.tc}"), {
+  test_that(glue::glue("mod_ext parses {.tc} [BBR-GPFO-024]"), {
     expect_identical(mod_ext(.tc), MOD_TEST_FILE)
   })
 }
@@ -186,7 +186,7 @@ for (.tc in .test_cases) {
   CTL_TEST_FILE
 )
 for (.tc in .test_cases) {
-  test_that(glue::glue("yaml_ext parses {.tc}"), {
+  test_that(glue::glue("yaml_ext parses {.tc} [BBR-GPFO-025]"), {
     expect_identical(yaml_ext(.tc), YAML_TEST_FILE)
   })
 }

--- a/tests/testthat/test-model-diff.R
+++ b/tests/testthat/test-model-diff.R
@@ -6,7 +6,7 @@ create_all_models()
 # teardown
 withr::defer(cleanup())
 
-test_that("model_diff.bbi_nonmem_model happy path based_on", {
+test_that("model_diff.bbi_nonmem_model happy path based_on [BBR-MDF-001]", {
   res_object <- model_diff(read_model(MOD2_ABS_PATH))
   expect_true(inherits(res_object, "Diff"))
 
@@ -17,7 +17,7 @@ test_that("model_diff.bbi_nonmem_model happy path based_on", {
   ))
 })
 
-test_that("model_diff.bbi_nonmem_model happy path .mod2 arg", {
+test_that("model_diff.bbi_nonmem_model happy path .mod2 arg [BBR-MDF-002]", {
   res_object <- model_diff(
     read_model(MOD2_ABS_PATH),
     read_model(MOD3_ABS_PATH)
@@ -32,14 +32,14 @@ test_that("model_diff.bbi_nonmem_model happy path .mod2 arg", {
 })
 
 
-test_that("model_diff.bbi_nonmem_model errors with no based_on", {
+test_that("model_diff.bbi_nonmem_model errors with no based_on [BBR-MDF-003]", {
   expect_error(
     model_diff(MOD1),
     regexp = paste0("no models.+", MODEL_DIFF_ERR_MSG)
   )
 })
 
-test_that("model_diff.bbi_nonmem_model errors with multiple based_on", {
+test_that("model_diff.bbi_nonmem_model errors with multiple based_on [BBR-MDF-004]", {
   mod4 <- read_model(MOD4_ABS_PATH) %>%
     add_based_on("../3")
 

--- a/tests/testthat/test-model-summaries.R
+++ b/tests/testthat/test-model-summaries.R
@@ -32,7 +32,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   # extracting things from summary object
   #########################################
 
-  test_that("model_summaries.list produces expected output", {
+  test_that("model_summaries.list produces expected output [BBR-SUM-006]", {
     mods <- purrr::map(file.path(MODEL_DIR, seq(3)), read_model)
     expect_equal(length(mods), NUM_MODS)
     for (.m in mods) {
@@ -44,7 +44,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
 
   })
 
-  test_that("model_summaries.list fails with bad list", {
+  test_that("model_summaries.list fails with bad list [BBR-SUM-007]", {
     bad_mods <- list(read_model(file.path(MODEL_DIR, 1)), list(naw = "dawg"))
     expect_equal(length(bad_mods), 2)
     expect_equal(class(bad_mods[[1]]), NM_MOD_CLASS_LIST)
@@ -52,13 +52,13 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_error(model_summaries(bad_mods), regexp = "must contain only model objects")
   })
 
-  test_that("model_summaries.bbi_run_log_df produces expected output", {
+  test_that("model_summaries.bbi_run_log_df produces expected output [BBR-SUM-008]", {
     mod_sums <- run_log(MODEL_DIR) %>% model_summaries()
     test_mod_sums(mod_sums)
   })
 
 
-  test_that("as_summary_list.bbi_summary_log_df works", {
+  test_that("as_summary_list.bbi_summary_log_df works [BBR-SUM-009]", {
     mod_sums <- summary_log(MODEL_DIR) %>% as_summary_list()
     test_mod_sums(mod_sums)
   })

--- a/tests/testthat/test-model-summary.R
+++ b/tests/testthat/test-model-summary.R
@@ -8,7 +8,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   # extracting things from summary object
   #########################################
 
-  test_that("model_summary.bbi_nonmem_model produces expected output", {
+  test_that("model_summary.bbi_nonmem_model produces expected output [BBR-SUM-001]", {
 
     # get summary
     sum1 <- MOD1 %>% model_summary()
@@ -26,7 +26,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   # passing file flags
   #####################
 
-  test_that("model_summary() works with custom .ext file", {
+  test_that("model_summary() works with custom .ext file [BBR-SUM-002]", {
     on.exit({
       fs::dir_delete(NEW_MOD2)
       fs::file_delete(ctl_ext(NEW_MOD2))
@@ -75,7 +75,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     list(ext = "shk", missing = "shrinkage_details")
   )
   for (.tc in TEST_CASES) {
-    test_that(glue::glue("model_summary() works with no .{.tc$ext} file"), {
+    test_that(glue::glue("model_summary() works with no .{.tc$ext} file [BBR-SUM-003]"), {
       on.exit({
         fs::dir_delete(NEW_MOD2)
         fs::file_delete(ctl_ext(NEW_MOD2))
@@ -130,7 +130,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   # errors when expected
   #######################
 
-  test_that("model_summary() fails predictably if it can't find some parts (i.e. model isn't finished)", {
+  test_that("model_summary() fails predictably if it can't find some parts (i.e. model isn't finished) [BBR-SUM-004]", {
     on.exit({
       fs::dir_delete(NEW_MOD2)
       fs::file_delete(ctl_ext(NEW_MOD2))
@@ -150,7 +150,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_error(model_summary(mod2), regexp = NOT_FINISHED_ERR_MSG)
   })
 
-  test_that("model_summary() fails predictably if no .lst file present", {
+  test_that("model_summary() fails predictably if no .lst file present [BBR-SUM-005]", {
     on.exit({
       fs::dir_delete(NEW_MOD2)
       fs::file_delete(ctl_ext(NEW_MOD2))

--- a/tests/testthat/test-modify-model-field.R
+++ b/tests/testthat/test-modify-model-field.R
@@ -4,7 +4,7 @@ context("Modify attributes of model object")
 # modify_model_field and its wrappers
 ######################################
 
-test_that("modify_model_field() works correctly", {
+test_that("modify_model_field() works correctly [BBR-MMF-001]", {
   temp_mod_path <- create_temp_model()
 
   # make a spec from it
@@ -20,7 +20,7 @@ test_that("modify_model_field() works correctly", {
   expect_identical(rogue_spec[[YAML_TAGS]], c(ORIG_TAGS, NEW_TAGS))
 })
 
-test_that("modify_model_field() de-duplication works", {
+test_that("modify_model_field() de-duplication works [BBR-MMF-002]", {
   dupe_tags <- c("ha", "hey", "ha")
   uniq_tags <- c("ha", "hey")
 
@@ -38,14 +38,14 @@ test_that("modify_model_field() de-duplication works", {
   expect_identical(new_mod[[YAML_TAGS]], c(ORIG_TAGS, uniq_tags))
 })
 
-test_that("modify_model_field() errors with .append=T and .remove=T", {
+test_that("modify_model_field() errors with .append=T and .remove=T [BBR-MMF-003]", {
   expect_error(
     modify_model_field(MOD1, YAML_TAGS, ORIG_TAGS, .append = TRUE, .remove = TRUE),
     regexp = "cannot have both"
   )
 })
 
-test_that("add_tags() and replace_all_tags() work correctly", {
+test_that("add_tags() and replace_all_tags() work correctly [BBR-MMF-004]", {
   temp_mod_path <- create_temp_model()
 
   # make a spec from it
@@ -61,7 +61,7 @@ test_that("add_tags() and replace_all_tags() work correctly", {
   expect_identical(new_mod[[YAML_TAGS]], NEW_TAGS)
 })
 
-test_that("replace_model_field() works correctly", {
+test_that("replace_model_field() works correctly [BBR-MMF-005]", {
   temp_mod_path <- create_temp_model()
 
   # make a spec from it
@@ -78,26 +78,7 @@ test_that("replace_model_field() works correctly", {
 })
 
 
-test_that("remove_tags() works correctly", {
-  temp_mod_path <- create_temp_model()
-  test_tags <- c("one", "two", "three", "four", "five")
-  rem_tags <- c("two", "four", "bad")
-  ref_tags <- c("one", "three", "five")
-
-  # make a model object and replace the tags
-  new_mod <- read_model(temp_mod_path)
-  new_mod <- replace_all_tags(new_mod, test_tags)
-  expect_identical(new_mod[[YAML_TAGS]], test_tags)
-
-  # test removing
-  new_mod <- expect_warning(
-    remove_tags(new_mod, rem_tags),
-    regexp = "does not contain any of the following.+bad"
-  )
-  expect_identical(new_mod[[YAML_TAGS]], ref_tags)
-})
-
-test_that("add_notes() and replace_all_notes() work correctly", {
+test_that("add_notes() and replace_all_notes() work correctly [BBR-MMF-006]", {
   temp_mod_path <- create_temp_model()
   new_mod <- read_model(temp_mod_path)
   expect_null(new_mod[[YAML_NOTES]])
@@ -111,7 +92,7 @@ test_that("add_notes() and replace_all_notes() work correctly", {
   expect_identical(new_mod[[YAML_NOTES]], NEW_NOTES)
 })
 
-test_that("remove_notes() works correctly", {
+test_that("remove_notes() works correctly [BBR-MMF-007]", {
   temp_mod_path <- create_temp_model()
 
   # make a model object and replace the notes
@@ -127,7 +108,7 @@ test_that("remove_notes() works correctly", {
   expect_identical(new_mod[[YAML_NOTES]], NEW_NOTES)
 })
 
-test_that("replace_description() works correctly", {
+test_that("replace_description() works correctly [BBR-MMF-008]", {
   temp_mod_path <- create_temp_model()
 
   # make a spec from it
@@ -139,7 +120,7 @@ test_that("replace_description() works correctly", {
   expect_identical(new_mod[[YAML_DESCRIPTION]], NEW_DESC)
 })
 
-test_that("replace_description() can use NULL", {
+test_that("replace_description() can use NULL [BBR-MMF-009]", {
   temp_mod_path <- create_temp_model()
 
   # make a spec from it
@@ -151,7 +132,7 @@ test_that("replace_description() can use NULL", {
   expect_null(new_mod[[YAML_DESCRIPTION]])
 })
 
-test_that("replace_description() can use NA", {
+test_that("replace_description() can use NA [BBR-MMF-010]", {
   temp_mod_path <- create_temp_model()
 
   # make a spec from it
@@ -163,7 +144,7 @@ test_that("replace_description() can use NA", {
   expect_null(new_mod[[YAML_DESCRIPTION]])
 })
 
-test_that("add_bbi_args() and replace_all_bbi_args() work correctly", {
+test_that("add_bbi_args() and replace_all_bbi_args() work correctly [BBR-MMF-011]", {
   temp_mod_path <- create_temp_model()
 
   # make a spec from it
@@ -182,7 +163,7 @@ test_that("add_bbi_args() and replace_all_bbi_args() work correctly", {
 })
 
 
-test_that("add_tags etc. can be chained", {
+test_that("add_tags etc. can be chained [BBR-MMF-012]", {
   temp_mod_path <- create_temp_model()
 
   # make a spec from it
@@ -200,7 +181,7 @@ test_that("add_tags etc. can be chained", {
   expect_identical(new_mod[[YAML_DESCRIPTION]], NEW_DESC)
 })
 
-test_that("add_based_on() and replace_all_based_on() work correctly", {
+test_that("add_based_on() and replace_all_based_on() work correctly [BBR-MMF-013]", {
   temp_mod_path <- create_temp_model()
   parent_model_id <- get_model_id(create_temp_model())
   child_model_id <- get_model_id(temp_mod_path)
@@ -230,7 +211,7 @@ test_that("add_based_on() and replace_all_based_on() work correctly", {
 # check_yaml_in_sync gets triggered when it should
 ####################################################
 
-test_that("reconcile_yaml() pulls in new tags", {
+test_that("reconcile_yaml() pulls in new tags [BBR-MMF-014]", {
   temp_mod_path <- create_temp_model()
   temp_yaml <- fs::path_ext_set(temp_mod_path, "yaml")
 
@@ -249,11 +230,11 @@ test_that("reconcile_yaml() pulls in new tags", {
 })
 
 
-test_that("check_yaml_in_sync() passes when nothing has changed", {
+test_that("check_yaml_in_sync() passes when nothing has changed [BBR-MMF-015]", {
   expect_invisible(check_yaml_in_sync(MOD1))
 })
 
-test_that("check_yaml_in_sync() fails when YAML has changed and passes after reconciled", {
+test_that("check_yaml_in_sync() fails when YAML has changed and passes after reconciled [BBR-MMF-016]", {
   temp_mod_path <- create_temp_model()
   temp_yaml <- fs::path_ext_set(temp_mod_path, "yaml")
 
@@ -275,7 +256,7 @@ test_that("check_yaml_in_sync() fails when YAML has changed and passes after rec
   expect_identical(new_mod[[YAML_TAGS]], c(ORIG_TAGS, NEW_TAGS))
 })
 
-test_that("add_tags fails if it wasn't re-assigned previously (testing check_yaml_in_sync)", {
+test_that("add_tags fails if it wasn't re-assigned previously (testing check_yaml_in_sync) [BBR-MMF-017]", {
   temp_mod_path <- create_temp_model()
 
   # make a spec from it
@@ -293,7 +274,7 @@ test_that("add_tags fails if it wasn't re-assigned previously (testing check_yam
   expect_error(new_mod %>% replace_description(NEW_DESC), regexp = "Model NOT in sync with corresponding YAML file")
 })
 
-test_that("submit_model() fails YAML out of sync (testing check_yaml_in_sync)", {
+test_that("submit_model() fails YAML out of sync (testing check_yaml_in_sync) [BBR-MMF-018]", {
   temp_mod_path <- create_temp_model()
   temp_yaml <- fs::path_ext_set(temp_mod_path, "yaml")
 
@@ -307,7 +288,7 @@ test_that("submit_model() fails YAML out of sync (testing check_yaml_in_sync)", 
   expect_error(submit_model(new_mod, .dry_run = T), regexp = "Model NOT in sync with corresponding YAML file")
 })
 
-test_that("model_summary() fails YAML out of sync (testing check_yaml_in_sync)", {
+test_that("model_summary() fails YAML out of sync (testing check_yaml_in_sync) [BBR-MMF-019]", {
   temp_mod_path <- create_temp_model()
   temp_yaml <- fs::path_ext_set(temp_mod_path, "yaml")
 
@@ -321,7 +302,7 @@ test_that("model_summary() fails YAML out of sync (testing check_yaml_in_sync)",
   expect_error(model_summary(new_mod, .dry_run = T), regexp = "Model NOT in sync with corresponding YAML file")
 })
 
-test_that("copy_model_from() fails YAML out of sync (testing check_yaml_in_sync)", {
+test_that("copy_model_from() fails YAML out of sync (testing check_yaml_in_sync) [BBR-MMF-020]", {
   temp_mod_path <- create_temp_model()
   temp_yaml <- fs::path_ext_set(temp_mod_path, "yaml")
 
@@ -335,7 +316,7 @@ test_that("copy_model_from() fails YAML out of sync (testing check_yaml_in_sync)
   expect_error(copy_model_from(new_mod, "foo"), regexp = "Model NOT in sync with corresponding YAML file")
 })
 
-test_that("add_tags(), add_notes() and friends check for character vector", {
+test_that("add_tags(), add_notes() and friends check for character vector [BBR-MMF-021]", {
   temp_mod_path <- create_temp_model()
   new_mod <- read_model(temp_mod_path)
 
@@ -353,4 +334,23 @@ test_that("add_tags(), add_notes() and friends check for character vector", {
     expect_error(new_mod %>% fn(1:3))
     expect_error(new_mod %>% fn(list(1:3)))
   }
+})
+
+test_that("remove_tags() works correctly [BBR-MMF-022]", {
+  temp_mod_path <- create_temp_model()
+  test_tags <- c("one", "two", "three", "four", "five")
+  rem_tags <- c("two", "four", "bad")
+  ref_tags <- c("one", "three", "five")
+
+  # make a model object and replace the tags
+  new_mod <- read_model(temp_mod_path)
+  new_mod <- replace_all_tags(new_mod, test_tags)
+  expect_identical(new_mod[[YAML_TAGS]], test_tags)
+
+  # test removing
+  new_mod <- expect_warning(
+    remove_tags(new_mod, rem_tags),
+    regexp = "does not contain any of the following.+bad"
+  )
+  expect_identical(new_mod[[YAML_TAGS]], ref_tags)
 })

--- a/tests/testthat/test-new-model.R
+++ b/tests/testthat/test-new-model.R
@@ -1,11 +1,11 @@
 context("Testing function to create or read in model object")
 
 
-test_that("read_model() returns expected object", {
+test_that("read_model() returns expected object [BBR-NWMD-001]", {
   expect_equal(read_model(MOD1_PATH), REF_LIST_1)
 })
 
-test_that("read_model() returns expected object from no ext specified", {
+test_that("read_model() returns expected object from no ext specified [BBR-NWMD-002]", {
   temp_path <- file.path(ABS_MODEL_DIR, "temp.yaml")
   ctl_path <- fs::path_ext_set(temp_path, "ctl")
 
@@ -21,7 +21,7 @@ test_that("read_model() returns expected object from no ext specified", {
   expect_equal(mod2, REF_LIST_TMP)
 })
 
-test_that("read_model() can read a model whose path has a period", {
+test_that("read_model() can read a model whose path has a period [BBR-NWMD-003]", {
   temp_ctl <- tempfile(pattern = "file.", fileext = ".ctl")
   # ensure that `temp_ctl` exists
   readr::write_file("foo", temp_ctl)
@@ -34,7 +34,7 @@ test_that("read_model() can read a model whose path has a period", {
   expect_identical(class(mod), NM_MOD_CLASS_LIST)
 })
 
-test_that("new_model() creates new YAML file", {
+test_that("new_model() creates new YAML file [BBR-NWMD-004]", {
   temp_mod_path <- create_temp_model()
   fs::file_delete(fs::path_ext_set(temp_mod_path, "yaml"))
 
@@ -51,11 +51,11 @@ test_that("new_model() creates new YAML file", {
   expect_true(all(MODEL_REQ_KEYS %in% names(mod1b)))
 })
 
-test_that("new_model() throws an error if the model file does not exist", {
+test_that("new_model() throws an error if the model file does not exist [BBR-NWMD-005]", {
   expect_error(new_model("foo", "bar"), "No model file found")
 })
 
-test_that("compare read_model() and new_model() objects", {
+test_that("compare read_model() and new_model() objects [BBR-NWMD-006]", {
   temp_mod_path <- create_temp_model()
   fs::file_delete(fs::path_ext_set(temp_mod_path, "yaml"))
 
@@ -87,7 +87,7 @@ test_that("compare read_model() and new_model() objects", {
   }
 })
 
-test_that("new_model() .overwrite arg works", {
+test_that("new_model() .overwrite arg works [BBR-NWMD-007]", {
   temp_mod_path <- create_temp_model()
 
   # error if file exists
@@ -104,7 +104,7 @@ test_that("new_model() .overwrite arg works", {
 })
 
 
-test_that("new_model() .based_on arg works", {
+test_that("new_model() .based_on arg works [BBR-NWMD-008]", {
   temp_mod_path <- create_temp_model()
   parent_model_id <- get_model_id(create_temp_model())
   fs::file_delete(fs::path_ext_set(temp_mod_path, "yaml"))
@@ -118,7 +118,7 @@ test_that("new_model() .based_on arg works", {
   expect_equal(mod1a[[YAML_BASED_ON]], parent_model_id)
 })
 
-test_that("new_model() .based_on arg errors on fake model", {
+test_that("new_model() .based_on arg errors on fake model [BBR-NWMD-009]", {
   temp_mod_path <- ctl_ext(tempfile())
   writeLines("CREATED BY: new_model() .based_on arg errors on fake model", temp_mod_path)
   on.exit(fs::file_delete(temp_mod_path))
@@ -134,7 +134,7 @@ test_that("new_model() .based_on arg errors on fake model", {
   )
 })
 
-test_that("new_model() supports `.path` containing a period", {
+test_that("new_model() supports `.path` containing a period [BBR-NWMD-010]", {
   temp_ctl <- tempfile(pattern = "file.", fileext = ".ctl")
   # ensure that `temp_ctl` exists
   readr::write_file("foo", temp_ctl)

--- a/tests/testthat/test-param-estimates-batch.R
+++ b/tests/testthat/test-param-estimates-batch.R
@@ -8,7 +8,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   # creating parameter summary tibble
   #########################################
 
-  test_that("param_estimates_batch produces expected output", {
+  test_that("param_estimates_batch produces expected output [BBR-PEST-005]", {
 
     on.exit(cleanup())
 
@@ -40,7 +40,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   # different number of params
   #####################
 
-  test_that("param_estimates_batch() works with varying number of param estimates", {
+  test_that("param_estimates_batch() works with varying number of param estimates [BBR-PEST-006]", {
 
     on.exit(cleanup())
 
@@ -64,7 +64,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   # empty extension file
   #####################
 
-  test_that("param_estimates_batch() works if an .ext file detected is empty", {
+  test_that("param_estimates_batch() works if an .ext file detected is empty [BBR-PEST-007]", {
 
     on.exit(cleanup())
 
@@ -93,7 +93,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   # missing termination line
   #####################
 
-  test_that("param_estimates_batch() works if the termination line is missing in an .ext file", {
+  test_that("param_estimates_batch() works if the termination line is missing in an .ext file [BBR-PEST-008]", {
 
     on.exit(cleanup())
 

--- a/tests/testthat/test-param-estimates.R
+++ b/tests/testthat/test-param-estimates.R
@@ -11,12 +11,12 @@ ref_df1 <- dget(PARAM_REF_FILE)
 
 withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
 
-  test_that("param_estimates.bbi_model_summary gets expected table", {
+  test_that("param_estimates.bbi_model_summary gets expected table [BBR-PEST-001]", {
     par_df <- MOD1 %>% model_summary() %>% param_estimates()
     expect_equal(par_df, ref_df1)
   })
 
-  test_that("param_estimates correctly errors on Bayesian model", {
+  test_that("param_estimates correctly errors on Bayesian model [BBR-PEST-002]", {
     mod1 <- read_model(file.path(MODEL_DIR_X, "1001"))
     sum1 <- model_summary(mod1, .bbi_args = list(ext_file = "1001.1.TXT"))
     expect_error(
@@ -25,7 +25,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     )
   })
 
-  test_that("param_estimates correctly errors on Bayesian model with multiple estimation methods", {
+  test_that("param_estimates correctly errors on Bayesian model with multiple estimation methods [BBR-PEST-003]", {
     sum1 <- file.path(MODEL_DIR_X, "acop-fake-bayes") %>%
       read_model() %>%
       model_summary()
@@ -35,7 +35,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     )
   })
 
-  test_that("param_estimates correctly warns on mixture model", {
+  test_that("param_estimates correctly warns on mixture model [BBR-PEST-004]", {
     mod1 <- read_model(file.path(MODEL_DIR_X, "iovmm"))
     sum1 <- model_summary(mod1)
 

--- a/tests/testthat/test-param-labels.R
+++ b/tests/testthat/test-param-labels.R
@@ -18,7 +18,7 @@ MODEL_PICKS <- list(
 # test_that("parse_param_comment() parses correctly ...", {...})
 
 for (.tc in names(MAT_REF)) {
-  test_that(glue("build_matrix_indices() parses correctly for {.tc}"), {
+  test_that(glue("build_matrix_indices() parses correctly {.tc} [BBR-PLB-001]"), {
     ref_df <- MAT_REF[[.tc]]
 
     test_ind <- build_matrix_indices(ref_df$is_diag)
@@ -28,20 +28,20 @@ for (.tc in names(MAT_REF)) {
 
 
 for (i in length(BLOCK_REF)) {
-  test_that(glue("block() parses correctly {i}"), {
+  test_that(glue("block() parses correctly {i} [BBR-PLB-002]"), {
     expect_equal(block(i), BLOCK_REF[[i]])
   })
 }
 
 
-test_that("param_labels.character errors on vector", {
+test_that("param_labels.character errors on vector [BBR-PLB-003]", {
   expect_error(param_labels(c("naw", "dawg")), regexp = "character scalar of the raw control stream")
 })
 
 
 # test parsing labels from different OMEGA and SIGMA blocks
 for (.test_name in names(PARAM_BLOCK_REF)) {
-  test_that(glue("parse_param_comment() called internally on {.test_name}"), {
+  test_that(glue("parse_param_comment() called internally {.test_name} [BBR-PLB-004]"), {
     .tc <- PARAM_BLOCK_REF[[.test_name]]
     res_df <- .tc$ctl %>% param_labels() %>% apply_indices(.omega = .tc$omega, .sigma = .tc$sigma)
     expect_equal(res_df, .tc$ref)
@@ -53,7 +53,7 @@ for (.test_name in names(PARAM_BLOCK_REF)) {
 for (MODEL_PICK in MODEL_PICKS) {
   .mod_id <- MODEL_PICK$mod_id
 
-  test_that(glue("param_labels.character() %>% apply_indices() matches tidynm reference for {.mod_id}"), {
+  test_that(glue("param_labels.character() %>% apply_indices() matches tidynm reference {.mod_id} [BBR-PLB-005]"), {
     # get reference df from tidynm test data
     ref_df <- readRDS(file.path(REF_DIR, "param-labels", glue("{.mod_id}_PARAMTBL.rds")))[[1]]
     names(ref_df) <- names(ref_df) %>% tolower()
@@ -89,7 +89,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   for (MODEL_PICK in MODEL_PICKS) {
     .mod_id <- MODEL_PICK$mod_id
 
-    test_that(glue("param_labels.bbi_nonmem_model() %>% apply_indices() matches tidynm reference for {.mod_id}"), {
+    test_that(glue("param_labels.bbi_nonmem_model() %>% apply_indices() matches tidynm reference {.mod_id} [BBR-PLB-006]"), {
       # get reference df from tidynm test data
       ref_df <- readRDS(file.path(REF_DIR, "param-labels", glue("{.mod_id}_PARAMTBL.rds")))[[1]]
       names(ref_df) <- names(ref_df) %>% tolower()

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -10,14 +10,14 @@ model_1 <- MOD1
 withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   withr::local_envvar(c("NO_COLOR" = "true"))
 
-  test_that("print.bbi_process works with .wait = TRUE", {
+  test_that("print.bbi_process works with .wait = TRUE [BBR-PRNT-001]", {
     proc <- bbi_exec("--help", .wait = TRUE)
     res <- capture.output(print(proc))
     expect_true(any(str_detect(res, PROC_HELP_STR)))
     expect_true(any(str_detect(res, "Process finished.")))
   })
 
-  test_that("print.bbi_process works with .wait = FALSE", {
+  test_that("print.bbi_process works with .wait = FALSE [BBR-PRNT-002]", {
     proc <- bbi_exec("--help", .wait = FALSE)
     res <- capture.output(print(proc))
 
@@ -25,14 +25,14 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_true(any(str_detect(res, "Not waiting for process to finish.")))
   })
 
-  test_that("print.bbi_process works with dry run", {
+  test_that("print.bbi_process works with dry run [BBR-PRNT-003]", {
     proc <- bbi_dry_run("--help", ".")
     res <- capture.output(print(proc))
     expect_true(any(str_detect(res, PROC_HELP_STR)))
     expect_true(any(str_detect(res, "DRY RUN! Process not actually run.")))
   })
 
-  test_that("print.bbi_process(.call_limit) works", {
+  test_that("print.bbi_process(.call_limit) works [BBR-PRNT-004]", {
     # create a bunch of fake models
     temp_dir <- file.path(get_model_working_directory(MOD1), "print-test")
     fs::dir_create(temp_dir)
@@ -53,7 +53,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_true(str_detect(call_str, "--overwrite --threads=4"))
   })
 
-  test_that("print.bbi_nonmem_model contains proper fields if all present", {
+  test_that("print.bbi_nonmem_model contains proper fields if all present [BBR-PRNT-005]", {
     model_1[[YAML_NOTES]] <- c("x", "y")
 
     fields <- c('Status',
@@ -68,7 +68,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     })
   })
 
-  test_that("print.bbi_nonmem_model run status functions properly", {
+  test_that("print.bbi_nonmem_model run status functions properly [BBR-PRNT-006]", {
     bullets <- capture.output({ # these get thrown away, but we don't want them to print in the test output
       expect_message(print(model_1), regexp = "Finished Running")
 
@@ -81,7 +81,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     })
   })
 
-  test_that("print.bbi_nonmem_summary works basic FOCE model", {
+  test_that("print.bbi_nonmem_summary works basic FOCE model [BBR-PRNT-007]", {
     .s <- file.path(MODEL_DIR, 1) %>%
       read_model() %>%
       model_summary()
@@ -90,7 +90,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_equal(res_str, ref_str)
   })
 
-  test_that("print.bbi_nonmem_summary works mixture model", {
+  test_that("print.bbi_nonmem_summary works mixture model [BBR-PRNT-008]", {
     .s <- file.path(MODEL_DIR_X, "iovmm") %>%
         read_model() %>%
         model_summary()
@@ -101,7 +101,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_equal(res_str, ref_str)
   })
 
-  test_that("print.bbi_nonmem_summary works Bayes model", {
+  test_that("print.bbi_nonmem_summary works Bayes model [BBR-PRNT-009]", {
     .s <- file.path(MODEL_DIR_X, "1001") %>%
       read_model() %>%
       model_summary(.bbi_args = list(ext_file = "1001.1.TXT"))
@@ -110,7 +110,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_equal(res_str, ref_str)
   })
 
-  test_that("print.bbi_nonmem_summary works SAEM-IMP model", {
+  test_that("print.bbi_nonmem_summary works SAEM-IMP model [BBR-PRNT-010]", {
     .s <- file.path(MODEL_DIR_X, "example2_saemimp") %>%
       read_model() %>%
       model_summary()
@@ -119,7 +119,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_equal(res_str, ref_str)
   })
 
-  test_that("print.bbi_nonmem_summary works IOV model", {
+  test_that("print.bbi_nonmem_summary works IOV model [BBR-PRNT-011]", {
     # load a model summary
     .s <- file.path(MODEL_DIR_X, "acop-iov") %>%
       read_model() %>%
@@ -129,7 +129,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_equal(res_str, ref_str)
   })
 
-  test_that("print.bbi_nonmem_summary .fixed=TRUE", {
+  test_that("print.bbi_nonmem_summary .fixed=TRUE [BBR-PRNT-012]", {
     # check with IOV model
     .s <- file.path(MODEL_DIR_X, "acop-iov") %>%
       read_model() %>%
@@ -147,7 +147,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_equal(res_str, ref_str)
   })
 
-  test_that("print.bbi_nonmem_summary .nrow argument", {
+  test_that("print.bbi_nonmem_summary .nrow argument [BBR-PRNT-013]", {
     # load a model summary
     .s <- file.path(MODEL_DIR_X, "acop-iov") %>%
       read_model() %>%
@@ -158,7 +158,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   })
 
 
-  test_that("print.bbi_nonmem_summary .off_diag=TRUE", {
+  test_that("print.bbi_nonmem_summary .off_diag=TRUE [BBR-PRNT-014]", {
     .s <- file.path(MODEL_DIR_X, "example2_saemimp") %>%
       read_model() %>%
       model_summary()

--- a/tests/testthat/test-read-bbi-path.R
+++ b/tests/testthat/test-read-bbi-path.R
@@ -1,6 +1,6 @@
 context("read_bbi_path() helper function")
 
-test_that("read_bbi_path() looks for environment variable", {
+test_that("read_bbi_path() looks for environment variable [BBR-RBP-001]", {
   withr::with_envvar(
     c("BBI_EXE_PATH" = "foo"),
     expect_equal(read_bbi_path(), "foo")

--- a/tests/testthat/test-read-output.R
+++ b/tests/testthat/test-read-output.R
@@ -33,7 +33,7 @@ GRD_REF_FLOOR_NULL <- paste0(GRD_STEM, "floorNULL.R")
 # tests
 ################
 
-test_that("check_file returns correctly", {
+test_that("check_file returns correctly [BBR-ROT-001]", {
   # default is to print and return nothing
   null_output <- capture.output(
     expect_invisible(check_file(LST_TEST_FILE))
@@ -59,7 +59,7 @@ test_that("check_file returns correctly", {
   list(head_test = 100000, tail_test = 100000, ref = LST_FULL_VEC)
 )
 for (.tc in .test_cases) {
-  test_that(glue::glue("check_file head={.tc[['head_test']]} tail={.tc[['tail_test']]}"), {
+  test_that(glue::glue("check_file head={.tc[['head_test']]} tail={.tc[['tail_test']]} [BBR-ROT-002]"), {
     res <- check_file(LST_TEST_FILE, .print = FALSE, .return = TRUE, .head = .tc[['head_test']], .tail = .tc[['tail_test']])
     expect_identical(res, .tc[['ref']])
   })
@@ -75,7 +75,7 @@ withr::with_file(OUTPUT_FILE, {
     list(.test_arg = MOD1, .test_name = "tail_output() model object")
   )
   for (.tc in .test_cases) {
-    test_that(.tc[[".test_name"]], {
+    test_that(paste(.tc[[".test_name"]], "[BBR-ROT-003]"), {
       res <- tail_output(.tc[[".test_arg"]], .print = FALSE, .return = TRUE)
       expect_identical(res, LST_REF_DEFAULT)
     })
@@ -89,7 +89,7 @@ withr::with_file(OUTPUT_FILE, {
   list(.test_arg = MOD1, .test_name = "tail_lst() model object")
 )
 for (.tc in .test_cases) {
-  test_that(.tc[[".test_name"]], {
+  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-004]"), {
     res <- tail_lst(.tc[[".test_arg"]], .print = FALSE, .return = TRUE)
     expect_identical(res, LST_REF_DEFAULT)
   })
@@ -106,7 +106,7 @@ for (.tc in .test_cases) {
   list(.test_arg = MOD1, .test_name = "check_output_dir() model object")
 )
 for (.tc in .test_cases) {
-  test_that(.tc[[".test_name"]], {
+  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-005]"), {
     res <- check_output_dir(.tc[[".test_arg"]])
     expect_identical(basename(res), basename(OUTPUT_DIR_LS))
   })
@@ -118,7 +118,7 @@ for (.tc in .test_cases) {
   list(.test_arg = MOD1, .test_name = "check_output_dir() model object with filter")
 )
 for (.tc in .test_cases) {
-  test_that(.tc[[".test_name"]], {
+  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-006]"), {
     res <- check_output_dir(.tc[[".test_arg"]], regexp = CTL_FILTER)
     expect_identical(basename(res), basename(CTL_FILTER_RES))
   })
@@ -129,7 +129,7 @@ for (.tc in .test_cases) {
 # check table functionality
 #######################################
 
-test_that("check_nonmem_table_output() output matches ref df", {
+test_that("check_nonmem_table_output() output matches ref df [BBR-ROT-007]", {
   df <- check_nonmem_table_output(file.path(MOD1_PATH, paste0(MOD_ID, ".ext")), .x_var = "ITERATION")
   ref_df <- dget(EXT_REF_FLOOR_NULL)
 
@@ -141,7 +141,7 @@ test_that("check_nonmem_table_output() output matches ref df", {
 
 })
 
-test_that("check_nonmem_table_output(.x_floor=0) works", {
+test_that("check_nonmem_table_output(.x_floor=0) works [BBR-ROT-008]", {
   df <- check_nonmem_table_output(file.path(MOD1_PATH, paste0(MOD_ID, ".ext")), .x_var = "ITERATION", .x_floor = 0)
   ref_df <- dget(EXT_REF_FLOOR_0)
 
@@ -158,7 +158,7 @@ test_that("check_nonmem_table_output(.x_floor=0) works", {
   list(.test_arg = MOD1, .test_name = "check_ext() model object default .iter_floor")
 )
 for (.tc in .test_cases) {
-  test_that(.tc[[".test_name"]], {
+  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-009]"), {
     df <- check_ext(.tc[[".test_arg"]])
     ref_df <- dget(EXT_REF_FLOOR_0)
 
@@ -173,7 +173,7 @@ for (.tc in .test_cases) {
   })
 }
 
-test_that("check_ext() summary object", {
+test_that("check_ext() summary object [BBR-ROT-010]", {
   skip_if_not_drone_or_metworx("check_ext() summary object")
   df <- check_ext(SUM1)
   ref_df <- dget(EXT_REF_FLOOR_0)
@@ -190,7 +190,7 @@ test_that("check_ext() summary object", {
   list(.test_arg = MOD1, .test_name = "check_ext() model object .iter_floor NULL")
 )
 for (.tc in .test_cases) {
-  test_that(.tc[[".test_name"]], {
+  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-011]"), {
     df <- check_ext(.tc[[".test_arg"]], .iter_floor = NULL)
     ref_df <- dget(EXT_REF_FLOOR_NULL)
 
@@ -211,7 +211,7 @@ for (.tc in .test_cases) {
   list(.test_arg = MOD1, .test_name = "check_grd() model object default .iter_floor")
 )
 for (.tc in .test_cases) {
-  test_that(.tc[[".test_name"]], {
+  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-012]"), {
     df <- check_grd(.tc[[".test_arg"]])
     ref_df <- dget(GRD_REF_FLOOR_0)
     expect_equal(df, ref_df)
@@ -224,7 +224,7 @@ for (.tc in .test_cases) {
   })
 }
 
-test_that("check_grd() summary object", {
+test_that("check_grd() summary object [BBR-ROT-013]", {
   skip_if_not_drone_or_metworx("check_grd() summary object")
   df <- check_grd(SUM1)
   ref_df <- dget(GRD_REF_FLOOR_0)
@@ -236,7 +236,7 @@ test_that("check_grd() summary object", {
   list(.test_arg = MOD1, .test_name = "check_grd() model object .iter_floor 10")
 )
 for (.tc in .test_cases) {
-  test_that(.tc[[".test_name"]], {
+  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-014]"), {
     df <- check_grd(.tc[[".test_arg"]], .iter_floor = 10)
     ref_df <- dget(GRD_REF_FLOOR_10)
     expect_equal(df, ref_df)
@@ -254,7 +254,7 @@ for (.tc in .test_cases) {
   list(.test_arg = MOD1, .test_name = "check_grd() model object .iter_floor NULL")
 )
 for (.tc in .test_cases) {
-  test_that(.tc[[".test_name"]], {
+  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-015]"), {
     df <- check_grd(.tc[[".test_arg"]], .iter_floor = NULL)
     ref_df <- dget(GRD_REF_FLOOR_NULL)
     expect_equal(df, ref_df)

--- a/tests/testthat/test-run-log.R
+++ b/tests/testthat/test-run-log.R
@@ -6,7 +6,7 @@ create_rlg_models()
 # teardown
 withr::defer(cleanup())
 
-test_that("run_log() errors with malformed YAML", {
+test_that("run_log() errors with malformed YAML [BBR-RNLG-001]", {
   temp_dir <- file.path(tempdir(), "run_log_malformed_yaml_test")
   fs::dir_create(temp_dir)
   temp_yaml <- fs::file_copy(file.path(REF_DIR, "test-yaml", "zz_fail_no_modtype.yaml"), temp_dir)
@@ -22,14 +22,14 @@ test_that("run_log() errors with malformed YAML", {
   )
 })
 
-test_that("run_log returns NULL and warns when no YAML found", {
+test_that("run_log returns NULL and warns when no YAML found [BBR-RNLG-002]", {
   log_df <- expect_warning(run_log(file.path(REF_DIR, "read-output-refs")), regexp = "Found no valid model YAML files in")
   expect_true(inherits(log_df, "tbl"))
   expect_equal(nrow(log_df), 0)
   expect_equal(ncol(log_df), 0)
 })
 
-test_that("run_log matches reference", {
+test_that("run_log matches reference [BBR-RNLG-003]", {
   log_df <- run_log(MODEL_DIR)
   expect_equal(nrow(log_df), RUN_LOG_ROWS)
   expect_equal(ncol(log_df), RUN_LOG_COLS)
@@ -71,7 +71,7 @@ fs::dir_create(LEVEL2_DIR)
 copy_model_from(MOD1, file.path(LEVEL2_SUBDIR, MOD_ID), "level 2 copy of 1.yaml", .inherit_tags = TRUE)
 fs::dir_copy(MOD1_PATH, LEVEL2_MOD)
 
-test_that("run_log() works correctly with nested dirs", {
+test_that("run_log() works correctly with nested dirs [BBR-RNLG-004]", {
   log_df <- run_log(MODEL_DIR)
   expect_equal(nrow(log_df), RUN_LOG_ROWS+1)
   expect_equal(ncol(log_df), RUN_LOG_COLS)

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -12,7 +12,7 @@ model_dir <- ABS_MODEL_DIR
 mod_ctl_path <- file.path(model_dir, CTL_FILENAME)
 
 withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
-  test_that("submit_model(.dry_run=T) returns correct command string",
+  test_that("submit_model(.dry_run=T) returns correct command string [BBR-SBMT-001]",
             {
               # correctly parsing yaml
               expect_identical(
@@ -39,7 +39,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               )
             })
 
-  test_that("submit_model(.dry_run=T) with bbi_nonmem_model object parses correctly",
+  test_that("submit_model(.dry_run=T) with bbi_nonmem_model object parses correctly [BBR-SBMT-002]",
             {
               # correctly parsing yaml
               expect_identical(
@@ -54,7 +54,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               )
             })
 
-  test_that("submit_model() creates correct call for non-NULL .config_path", {
+  test_that("submit_model() creates correct call for non-NULL .config_path [BBR-SBMT-003]", {
 
     temp_config <- tempfile(fileext = ".yaml")
     readr::write_file("foo", temp_config)
@@ -75,14 +75,14 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     )
   })
 
-  test_that("submit_model() throws an error if passed `output_dir` bbi arg", {
+  test_that("submit_model() throws an error if passed `output_dir` bbi arg [BBR-SBMT-004]", {
     expect_error(
       submit_model(MOD1, .bbi_args = list(output_dir = "foo")),
       "is not a valid argument"
     )
   })
 
-  test_that("submit_model(.mode) inherits option", {
+  test_that("submit_model(.mode) inherits option [BBR-SBMT-005]", {
     withr::with_options(list(bbr.bbi_exe_mode = "local"), {
       expect_identical(
         submit_model(MOD1, .dry_run = T)[[PROC_CALL]],
@@ -91,7 +91,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     })
   })
 
-  test_that("submit_model(.mode) errors when NULL", {
+  test_that("submit_model(.mode) errors when NULL [BBR-SBMT-006]", {
     withr::with_options(list(bbr.bbi_exe_mode = NULL), {
       expect_error(
         submit_model(MOD1, .dry_run = T),
@@ -100,7 +100,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     })
   })
 
-  test_that("submit_model(.mode) errors when invalid", {
+  test_that("submit_model(.mode) errors when invalid [BBR-SBMT-007]", {
     expect_error(
       submit_model(MOD1, .dry_run = T, .mode = "naw"),
       regexp = "Invalid value passed.+mode"

--- a/tests/testthat/test-submit-models.R
+++ b/tests/testthat/test-submit-models.R
@@ -16,7 +16,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     ~ file.path(model_dir, fs::path_ext_set(., "ctl"))
   )
 
-  test_that("submit_models(.dry_run=T) with list input simple",
+  test_that("submit_models(.dry_run=T) with list input simple [BBR-SBMT-008]",
             {
               # copy to two new models
               mod2 <- copy_model_from(MOD1, 2)
@@ -39,7 +39,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               )
             })
 
-  test_that("submit_models(.dry_run=T) with list input, 2 arg sets",
+  test_that("submit_models(.dry_run=T) with list input, 2 arg sets [BBR-SBMT-010]",
             {
               # copy to two new models
               mod2 <- copy_model_from(MOD1, 2) %>% add_bbi_args(list(threads = 3))
@@ -71,7 +71,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               )
             })
 
-  test_that("submit_models() works for models in different directories", {
+  test_that("submit_models() works for models in different directories [BBR-SBMT-011]", {
     new_dir <- "level2"
     fs::dir_create(file.path(MODEL_DIR, new_dir))
     on.exit(cleanup())
@@ -88,7 +88,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_equal(length(proc_list), 2L)
   })
 
-  test_that("submit_models(.dry_run=T) errors with bad input",
+  test_that("submit_models(.dry_run=T) errors with bad input [BBR-SBMT-012]",
             {
               # copy to two new models
               mod2 <- copy_model_from(MOD1, 2)
@@ -115,7 +115,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               )
             })
 
-  test_that("submit_models() works with non-NULL .config_path", {
+  test_that("submit_models() works with non-NULL .config_path [BBR-SBMT-013]", {
     temp_config <- tempfile(fileext = ".yaml")
     readr::write_file("foo", temp_config)
     temp_config <- normalizePath(temp_config)
@@ -140,7 +140,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     )
   })
 
-  test_that("submit_models() works if .bbi_args is empty", {
+  test_that("submit_models() works if .bbi_args is empty [BBR-SBMT-014]", {
     # set existing arguments to NULL via `.bbi_args`
     res <- submit_models(
       list(MOD1),
@@ -174,7 +174,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     )
   })
 
-  test_that("submit_models(.mode) inherits option", {
+  test_that("submit_models(.mode) inherits option [BBR-SBMT-015]", {
     withr::with_options(list(bbr.bbi_exe_mode = "local"), {
       expect_identical(
         submit_models(list(MOD1), .dry_run = T)[[1]][[PROC_CALL]],

--- a/tests/testthat/test-summary-log.R
+++ b/tests/testthat/test-summary-log.R
@@ -33,7 +33,7 @@ copy_all_output_dirs()
 withr::defer(cleanup())
 
 
-test_that("summary_log() returns NULL and warns when no YAML found", {
+test_that("summary_log() returns NULL and warns when no YAML found [BBR-SMLG-001]", {
   log_df <- expect_warning(summary_log(file.path(REF_DIR, "read-output-refs")), regexp = "Found no valid model YAML files in")
   expect_true(inherits(log_df, "tbl"))
   expect_equal(nrow(log_df), 0)
@@ -46,24 +46,24 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   # extracting things from summary object
   #########################################
 
-  test_that("summary_log() works correctly with nested dirs", {
+  test_that("summary_log() works correctly with nested dirs [BBR-SMLG-002]", {
     sum_df <- summary_log(MODEL_DIR)
     test_sum_df(sum_df, c(MOD1_PATH, NEW_MOD2, NEW_MOD3, LEVEL2_MOD), SUM_LOG_COLS)
   })
 
-  test_that("summary_log(.recurse = FALSE) works", {
+  test_that("summary_log(.recurse = FALSE) works [BBR-SMLG-003]", {
     sum_df <- summary_log(MODEL_DIR, .recurse = FALSE)
     test_sum_df(sum_df, c(MOD1_PATH, NEW_MOD2, NEW_MOD3), SUM_LOG_COLS)
   })
 
-  test_that("add_summary() works correctly", {
+  test_that("add_summary() works correctly [BBR-SMLG-004]", {
     sum_df <- run_log(MODEL_DIR) %>% add_summary()
     test_sum_df(sum_df, c(MOD1_PATH, NEW_MOD2, NEW_MOD3, LEVEL2_MOD), RUN_LOG_COLS+SUM_LOG_COLS-2)
     expect_identical(sum_df$model_type, rep("nonmem", RUN_LOG_ROWS+1))
     expect_identical(sum_df$yaml_md5, ALL_MODS_YAML_MD5)
   })
 
-  test_that("add_summary() has correct columns", {
+  test_that("add_summary() has correct columns [BBR-SMLG-005]", {
     sum_df <- summary_log(MODEL_DIR)
     log_df <- run_log(MODEL_DIR)
     add_df <- log_df %>% add_summary()
@@ -76,7 +76,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_identical(sum_df[[col_to_check]], add_df[[col_to_check]])
   })
 
-  test_that("summary_log() parses heuristics correctly", {
+  test_that("summary_log() parses heuristics correctly [BBR-SMLG-006]", {
     sum_df2 <- summary_log(MODEL_DIR_X, .fail_flags = list(ext_file = "1001.1.TXT"))
 
     expect_false(filter(sum_df2, run == "1001") %>% pull(minimization_terminated))
@@ -87,7 +87,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_true(filter(sum_df2, run == "iovmm") %>% pull(has_final_zero_gradient))
   })
 
-  test_that("summary_log() parses more complex flags and stats", {
+  test_that("summary_log() parses more complex flags and stats [BBR-SMLG-007]", {
     sum_df2 <- summary_log(MODEL_DIR_X, .fail_flags = list(ext_file = "1001.1.TXT"))
 
     # check fail flag parsed
@@ -103,7 +103,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   # THESE TESTS NEEDS TO BE LAST BECAUSE IT DELETES NECESSARY FILES
   fs::file_delete(file.path(LEVEL2_MOD, "1.grd"))
 
-  test_that("summary_log works some failed summaries", {
+  test_that("summary_log works some failed summaries [BBR-SMLG-008]", {
     sum_df <- summary_log(MODEL_DIR)
     expect_equal(is.na(sum_df$error_msg), c(TRUE, TRUE, TRUE, FALSE))
     expect_equal(ncol(sum_df), SUM_LOG_COLS)
@@ -112,7 +112,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     test_sum_df(sum_df, c(MOD1_PATH, NEW_MOD2, NEW_MOD3, LEVEL2_MOD), SUM_LOG_COLS)
   })
 
-  test_that("summary_log works all failed summaries", {
+  test_that("summary_log works all failed summaries [BBR-SMLG-009]", {
 
     expect_warning({
       sum_df <- summary_log(LEVEL2_DIR)
@@ -124,7 +124,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
 
   })
 
-  test_that("add_summary works all failed summaries", {
+  test_that("add_summary works all failed summaries [BBR-SMLG-010]", {
 
     expect_warning({
       sum_df <- run_log(LEVEL2_DIR) %>% add_summary()

--- a/tests/testthat/test-tags-diff.R
+++ b/tests/testthat/test-tags-diff.R
@@ -1,6 +1,6 @@
 context("Comparing tags between models")
 
-test_that("tags_diff.bbi_model default happy path works", {
+test_that("tags_diff.bbi_model default happy path works [BBR-TDF-001]", {
   new_mod <- copy_model_from(MOD1, "new_mod",
     .description = "tags_diff.bbi_model default happy path works",
     .inherit_tags = TRUE
@@ -14,7 +14,7 @@ test_that("tags_diff.bbi_model default happy path works", {
   expect_identical(diff_list[[TAGS_REM]], ORIG_TAGS[1])
 })
 
-test_that("tags_diff.bbi_model print works", {
+test_that("tags_diff.bbi_model print works [BBR-TDF-002]", {
   new_mod <- copy_model_from(MOD1, "new_mod",
    .description = "tags_diff.bbi_model print works",
    .inherit_tags = TRUE
@@ -33,7 +33,7 @@ test_that("tags_diff.bbi_model print works", {
   )
 })
 
-test_that("tags_diff.bbi_model .mod2 works", {
+test_that("tags_diff.bbi_model .mod2 works [BBR-TDF-003]", {
   temp_mod_path <- create_temp_model()
   new_mod <- temp_mod_path %>%
     read_model() %>%
@@ -54,7 +54,7 @@ test_that("tags_diff.bbi_model .mod2 works", {
   )
 })
 
-test_that("tags_diff.bbi_run_log_df works", {
+test_that("tags_diff.bbi_run_log_df works [BBR-TDF-004]", {
   # set up models for run log
   cleanup()
   create_rlg_models()

--- a/tests/testthat/test-use-bbi.R
+++ b/tests/testthat/test-use-bbi.R
@@ -5,7 +5,7 @@ skip_if_offline()
 
 tdir <- normalizePath(tempdir())
 
-test_that("use-bbi works on linux pulling from options", {
+test_that("use-bbi works on linux pulling from options [BBR-UBI-001]", {
   bbi_tmp_path <- file.path(tdir, "bbi1")
   on.exit(unlink(bbi_tmp_path))
   skip_if_over_rate_limit()
@@ -23,7 +23,7 @@ test_that("use-bbi works on linux pulling from options", {
   expect_equal(as.character(f_info$mode), '755')
 })
 
-test_that("use-bbi works on linux with path specified", {
+test_that("use-bbi works on linux with path specified [BBR-UBI-002]", {
   bbi_tmp_path <- file.path(tdir, "bbi2")
   on.exit(unlink(bbi_tmp_path))
   skip_if_over_rate_limit()
@@ -36,14 +36,14 @@ test_that("use-bbi works on linux with path specified", {
 })
 
 
-test_that("bbi_version returns nothing with fake bbi", {
+test_that("bbi_version returns nothing with fake bbi [BBR-UBI-003]", {
   withr::with_options(list("bbr.bbi_exe_path" = "/fake/path/bbi"), {
     expect_equal(bbi_version(), "")
   })
 })
 
 
-test_that("use_bbi .version argument works", {
+test_that("use_bbi .version argument works [BBR-UBI-004]", {
 
   skip_if_over_rate_limit()
   bbi_tmp_path <- file.path(tdir, "bbi3")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -4,7 +4,7 @@ context("Utility functions for building args, etc.")
 # parsing args
 ################
 
-test_that("check_bbi_args parses correctly", {
+test_that("check_bbi_args parses correctly [BBR-UTL-001]", {
   # check some that should parse correctly
   .arg_list <- list(
     list(list("json" = T, "threads" = 4, "nm_version" = "nm74"), c("--json", "--threads=4", "--nm_version=nm74")), # check flag conversion
@@ -29,7 +29,7 @@ test_that("check_bbi_args parses correctly", {
 })
 
 
-test_that("format_cmd_args parses correctly", {
+test_that("format_cmd_args parses correctly [BBR-UTL-002]", {
   # check some that should parse correctly
   .arg_list <- list(
     list(list("json" = T, "threads" = 4), c("json", "threads=4")), # check basic nonmem args
@@ -67,32 +67,32 @@ test_that("format_cmd_args parses correctly", {
 # list manipulation
 #####################
 
-test_that("parse_args_list() merges lists as expected", {
+test_that("parse_args_list() merges lists as expected [BBR-UTL-003]", {
   # override `naw` with .func_args
   expect_identical(parse_args_list(.func_args = LIST1, .yaml_args = LIST2), list(naw=4, saw="hey", paw=6))
 })
 
-test_that("parse_args_list() handles NULL as expected", {
+test_that("parse_args_list() handles NULL as expected [BBR-UTL-004]", {
   expect_identical(parse_args_list(NULL, LIST2), LIST2)
   expect_identical(parse_args_list(LIST1, NULL), LIST1)
   expect_identical(parse_args_list(NULL, NULL), list())
 })
 
-test_that("parse_args_list() correctly fails if .func_args isn't named", {
+test_that("parse_args_list() correctly fails if .func_args isn't named [BBR-UTL-005]", {
   # correctly fails if .func_args isn't named
   expect_error(parse_args_list(list(4,5,6), LIST2))
 })
 
 
-test_that("combine_list_objects() merges lists as expected", {
+test_that("combine_list_objects() merges lists as expected [BBR-UTL-006]", {
   expect_identical(combine_list_objects(.new_list = LIST1, .old_list = LIST2), list(naw=4, paw=6, saw="hey"))
 })
 
-test_that("combine_list_objects() merges with append=TRUE", {
+test_that("combine_list_objects() merges with append=TRUE [BBR-UTL-007]", {
   expect_identical(combine_list_objects(.new_list = LIST1, .old_list = LIST2, .append = TRUE), list(naw=c(4, 5), paw=6, saw="hey"))
 })
 
-test_that("combine_list_objects() correctly fails if .func_args isn't named", {
+test_that("combine_list_objects() correctly fails if .func_args isn't named [BBR-UTL-008]", {
   # correctly fails if .func_args isn't named
   expect_error(combine_list_objects(list(4,5,6), LIST2))
   expect_error(combine_list_objects(LIST1, list(4,5,6)))
@@ -103,14 +103,14 @@ test_that("combine_list_objects() correctly fails if .func_args isn't named", {
 # assorted utilities
 ######################
 
-test_that("check_required_keys() works correctly", {
+test_that("check_required_keys() works correctly [BBR-UTL-009]", {
   req_keys <- c("hey", "aww", "naw")
   expect_true(check_required_keys(list(hey = 1, aww = 2, naw = 3), req_keys))
   expect_false(check_required_keys(list(hey = 1, aww = 2), req_keys))
 })
 
 
-test_that("strict_mode_error() works correctly", {
+test_that("strict_mode_error() works correctly [BBR-UTL-010]", {
   withr::with_options(list(bbr.strict = TRUE), {
     expect_error(strict_mode_error("hello"))
   })
@@ -123,7 +123,7 @@ test_that("strict_mode_error() works correctly", {
 })
 
 
-test_that("suppressSpecificWarning() works", {
+test_that("suppressSpecificWarning() works [BBR-UTL-011]", {
   # log() of a negative number raises a warning
   x <- suppressSpecificWarning(log(-1), "NaNs produced")
   expect_true(is.nan(x))

--- a/tests/testthat/test-workflow-bbi.R
+++ b/tests/testthat/test-workflow-bbi.R
@@ -47,7 +47,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   # create model from R
   #######################
 
-  test_that("step by step create_model to submit_model to model_summary works", {
+  test_that("step by step create_model to submit_model to model_summary works [BBR-WRKF-001]", {
     # create model
     mod1 <- new_model(
       file.path(MODEL_DIR_BBI, "1"),
@@ -73,7 +73,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_equal(param_estimates(sum1), dget(PARAM_REF_FILE))
   })
 
-  test_that("copying model works and new models run correctly", {
+  test_that("copying model works and new models run correctly [BBR-WRKF-002]", {
     mod1 <- read_model(file.path(MODEL_DIR_BBI, "1"))
     mod2 <- copy_model_from(mod1, 2)
     mod3 <- copy_model_from(mod1, 3, .inherit_tags = TRUE) %>% add_bbi_args(list(clean_lvl=2, overwrite = FALSE))
@@ -100,7 +100,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
 
   })
 
-  test_that("config_log() works correctly", {
+  test_that("config_log() works correctly [BBR-WRKF-003]", {
     # check config log for all models so far
     log_df <- config_log(MODEL_DIR_BBI)
     expect_equal(nrow(log_df), 3)
@@ -110,14 +110,14 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_false(any(is.na(log_df$data_path)))
   })
 
-  test_that(".wait = FALSE returns correctly", {
+  test_that(".wait = FALSE returns correctly [BBR-WRKF-004]", {
     # launch a model but don't wait for it to finish
     mod1 <- read_model(file.path(MODEL_DIR_BBI, "1"))
     proc <- copy_model_from(mod1, 4, .inherit_tags = TRUE) %>% submit_model(.mode = "local", .wait = FALSE)
     expect_true(stringr::str_detect(proc[[PROC_STDOUT]], ".wait = FALSE"))
   })
 
-  test_that("run_log() captures runs correctly", {
+  test_that("run_log() captures runs correctly [BBR-WRKF-005]", {
     # check run log for all models
     log_df <- run_log(MODEL_DIR_BBI)
     expect_equal(nrow(log_df), 4)
@@ -127,7 +127,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_identical(log_df$tags, list(ORIG_TAGS, NEW_TAGS, ORIG_TAGS, ORIG_TAGS))
   })
 
-  test_that("add_config() works with in progress model run", {
+  test_that("add_config() works with in progress model run [BBR-WRKF-006]", {
     # add config log to run log
     log_df <- expect_warning(
       run_log(MODEL_DIR_BBI) %>% add_config(),
@@ -141,7 +141,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   })
 
 
-  test_that("submit_model() works with non-NULL .config_path", {
+  test_that("submit_model() works with non-NULL .config_path [BBR-WRKF-007]", {
     if (requireNamespace("withr", quietly = TRUE) &&
         utils::packageVersion("withr") < "2.2.0") {
       skip("must have withr >= 2.2.0 to run this test")


### PR DESCRIPTION
Note that this tagging depends on the new `mrgvalprep` feature in [this PR](https://github.com/metrumresearchgroup/mrgvalprep/pull/16), which allows rolling up of duplicate ID's. There were number of cases (for example [here](https://github.com/metrumresearchgroup/bbr/blob/test/adding_mrgval_ids/tests/testthat/test-get-path-from-object.R#L86-L97) and [here](https://github.com/metrumresearchgroup/bbr/blob/test/adding_mrgval_ids/tests/testthat/test-model-summary.R#L72-L78)) that would have required a very unfortunate refactor if we had not taken this approach. 

Given this ^ it's possible that we'll want to consolidate some of these test ID's to make them more manageable and make the docs less cluttered. For now though, I think this is the best approach (one unique ID per `test_that()` call, only duplicated when that call is in a loop or something similar).