### PR TITLE
find_models: continue to return unnamed list despite stringr change

### DIFF
--- a/R/run-log.R
+++ b/R/run-log.R
@@ -69,7 +69,7 @@ run_log <- function(.base_dir, .recurse = FALSE, .include = NULL) {
 find_models <- function(.base_dir, .recurse , .include) {
 
   # get yaml files
-  yaml_files <- dir_ls(.base_dir, recurse = .recurse)
+  yaml_files <- as.character(dir_ls(.base_dir, recurse = .recurse))
   yaml_files <- str_subset(yaml_files, "\\.ya?ml$")
   yaml_files <- str_subset(yaml_files, "bbi\\.ya?ml$", negate = TRUE)
   yaml_files <- prune_nested_models(yaml_files)

--- a/tests/testthat/test-run-log.R
+++ b/tests/testthat/test-run-log.R
@@ -271,3 +271,25 @@ test_that("find_models does not warn about filter when no models are found", {
     )
   })
 })
+
+test_that("find_models returns unnamed list", {
+  ctl_file <- fs::path_abs(CTL_TEST_FILE)
+  withr::with_tempdir({
+    expect_warning(
+      res <- find_models(".", .recurse = TRUE, .include = NULL),
+      "no valid model yaml files",
+      ignore.case = TRUE,
+      all = TRUE
+    )
+    expect_identical(res, list())
+
+    fs::file_copy(ctl_file, "a.ctl")
+    new_model("a")
+    fs::file_copy(ctl_file, "b.ctl")
+    new_model("b")
+
+    res <- find_models(".", .recurse = TRUE, .include = NULL)
+    expect_length(res, 2)
+    expect_null(names(res))
+  })
+})


### PR DESCRIPTION
bbr.bayes tests have [started to fail](https://github.com/metrumresearchgroup/bbr.bayes/actions/runs/19220950776/job/54938814925).  Those failures are triggered by `find_models` returning **a named list instead of an unnamed one**, which in turn is triggered by a stringr 1.6.0 change.  `str_subset` no longer strips names from its result.

The second commit of this series adjust `find_models` so that it consistently returns a named list.  The first commit tweaks nearby code to avoid a confusing warning that I noticed when writing the tests for this.