### PR TITLE
copy_model_from: update model ID by default

### DIFF
--- a/R/bootstrap-model.R
+++ b/R/bootstrap-model.R
@@ -49,6 +49,7 @@ new_bootstrap_run <- function(
     .add_tags = "BOOTSTRAP_SUBMISSION",
     .inherit_tags = .inherit_tags,
     .update_model_file = TRUE,
+    .update_id = FALSE,
     .overwrite = .overwrite
   )
 

--- a/R/copy-model-from.R
+++ b/R/copy-model-from.R
@@ -36,6 +36,7 @@
 #' @param .overwrite If `FALSE`, the default,  function will error if a model
 #'   file already exists at specified `.new_model` path. If `TRUE` any existing
 #'   file at `.new_model` will be overwritten silently.
+#' @param ... Arguments passed on to methods.
 #' @examples
 #' \dontrun{
 #' parent <- read_model("/foo/parent")
@@ -68,7 +69,8 @@ copy_model_from <- function(
     .star = NULL,
     .inherit_tags = FALSE,
     .update_model_file = TRUE,
-    .overwrite = FALSE
+    .overwrite = FALSE,
+    ...
 ) {
   UseMethod("copy_model_from")
 }
@@ -84,7 +86,8 @@ copy_model_from.bbi_nonmem_model <- function(
     .star = NULL,
     .inherit_tags = FALSE,
     .update_model_file = TRUE,
-    .overwrite = FALSE
+    .overwrite = FALSE,
+    ...
 ) {
 
   .new_model <- build_new_model_path(.parent_mod, .new_model)

--- a/R/copy-model-from.R
+++ b/R/copy-model-from.R
@@ -29,10 +29,8 @@
 #'   tags passed to `.add_tags` argument. If `TRUE` inherit any tags from
 #'   `.parent_mod`, with any tags passed to `.add_tags` appended.
 #' @param .update_model_file **Only relevant to NONMEM models.** If `TRUE`, the
-#'   default, update the newly created model file. If `FALSE`, new model file
-#'   will be an exact copy of its parent. For a NONMEM model, this currently
-#'   means only the `$PROBLEM` line in the new control stream will be updated to
-#'   read `See {.new_model}.yaml. Created by bbr.`.
+#'   default, update the newly created model file by setting the `$PROBLEM` line
+#'   in the new control stream to read `See {.new_model}.yaml. Created by bbr.`.
 #' @param .overwrite If `FALSE`, the default,  function will error if a model
 #'   file already exists at specified `.new_model` path. If `TRUE` any existing
 #'   file at `.new_model` will be overwritten silently.

--- a/R/copy-model-from.R
+++ b/R/copy-model-from.R
@@ -130,10 +130,6 @@ copy_model_from.bbi_nonmem_model <- function(
 #' Used for iterating on model development. Also fills in necessary YAML fields
 #' for using `run_log()` later.
 #' @param .parent_mod S3 object of class `bbi_{.model_type}_model` to be used as the basis for copy.
-#' @param .update_model_file **Only relevant for NONMEM models.** If `TRUE`, the
-#'   default, update the `$PROBLEM` line in the new control stream. If `FALSE`,
-#'   `{.new_model}.[mod|ctl]` will be an exact copy of its parent control
-#'   stream.
 #' @param setup_fn A function to call (with no arguments) before creating the
 #'   model with [new_model()].
 #' @inheritParams copy_model_from
@@ -204,7 +200,7 @@ copy_model_from_impl <- function(
 #' @param .parent_model_path Path to the control stream to copy
 #' @param .new_model_path Path to copy the new control stream to
 #' @param .overwrite If `TRUE`, overwrite existing file at `.new_model_path`. If `FALSE` and file exists at `.new_model_path` error.
-#' @param .update_model_file If `TRUE`, the default, update the `$PROBLEM` line in the new control stream. If `FALSE`, `{.new_model}.[mod|ctl]` will be an exact copy of its parent control stream.
+#' @inheritParams copy_model_from
 #' @keywords internal
 copy_control_stream <- function(.parent_model_path, .new_model_path, .overwrite, .update_model_file = FALSE) {
 

--- a/R/copy-model-from.R
+++ b/R/copy-model-from.R
@@ -74,6 +74,10 @@ copy_model_from <- function(
 }
 
 #' @describeIn copy_model_from `.parent_mod` takes a `bbi_nonmem_model` object to use as a basis for the copy.
+#' @param .update_id Whether to call [update_model_id()] to replace occurrences
+#'   of `{parent_mod}.{suffix}` with the ID of the new model. To override or
+#'   extend the default suffixes, set this argument to `FALSE` and follow up
+#'   with a direct call to [update_model_id()].
 #' @export
 copy_model_from.bbi_nonmem_model <- function(
     .parent_mod,
@@ -85,7 +89,8 @@ copy_model_from.bbi_nonmem_model <- function(
     .inherit_tags = FALSE,
     .update_model_file = TRUE,
     .overwrite = FALSE,
-    ...
+    ...,
+    .update_id = TRUE
 ) {
 
   .new_model <- build_new_model_path(.parent_mod, .new_model)
@@ -108,6 +113,7 @@ copy_model_from.bbi_nonmem_model <- function(
     .inherit_tags = .inherit_tags,
     .update_model_file = .update_model_file,
     .overwrite = .overwrite,
+    .update_id = .update_id,
     setup_fn = copy_ctl
   )
 
@@ -149,6 +155,7 @@ copy_model_from_impl <- function(
     .inherit_tags = FALSE,
     .update_model_file = TRUE,
     .overwrite = FALSE,
+    .update_id = TRUE,
     setup_fn = NULL
 ) {
   check_for_existing_model(.new_model, .overwrite)
@@ -186,6 +193,10 @@ copy_model_from_impl <- function(
     .overwrite = FALSE, # will have already overwritten if necessary
     .model_type = mtype
   )
+
+  if (isTRUE(.update_id)) {
+    .new_mod <- update_model_id(.new_mod)
+  }
 
   return(.new_mod)
 }

--- a/R/copy-model-helpers.R
+++ b/R/copy-model-helpers.R
@@ -90,7 +90,7 @@ update_model_id <- function(
   )
 
   txt <- gsub(
-    paste0("\\Q",based_on_id,"\\E", .suffixes),
+    paste0("\\b\\Q",based_on_id,"\\E", .suffixes),
     paste0(mod_id, "\\1"),
     txt,
     ignore.case = TRUE

--- a/R/copy-model-helpers.R
+++ b/R/copy-model-helpers.R
@@ -70,7 +70,7 @@ update_model_id <- function(
   if (is.null(based_on)) {
     stop(glue("Cannot call update_model_id() because .mod$based_on is empty for model {mod_id}"))
   }else{
-    based_on_id <- get_model_id(based_on)
+    based_on_id <- get_model_id(based_on)[1]
   }
   message(glue("replacing {based_on_id} with {mod_id} in {modelfile}"))
 

--- a/R/copy-model-helpers.R
+++ b/R/copy-model-helpers.R
@@ -67,11 +67,11 @@ update_model_id <- function(
   modelfile <- get_model_path(.mod)
   based_on <- get_based_on(.mod)
 
-  if (is.null(based_on)) {
+  if (!length(based_on)) {
     stop(glue("Cannot call update_model_id() because .mod$based_on is empty for model {mod_id}"))
-  }else{
-    based_on_id <- get_model_id(based_on)[1]
   }
+  based_on_id <- get_model_id(based_on)[1]
+
   message(glue("replacing {based_on_id} with {mod_id} in {modelfile}"))
 
   ## construct suffixes regex string

--- a/R/copy-model-helpers.R
+++ b/R/copy-model-helpers.R
@@ -30,6 +30,11 @@
 #' _both_ be replaced, but the case of the suffix in the control stream will be
 #' maintained as is.
 #'
+#' As of bbr 1.15.0, [copy_model_from()] by default calls `update_model_id()`
+#' internally before returning the model. You do not need to call
+#' `update_model_id()` directly unless you want to override or extend the
+#' default suffixes.
+#'
 #' @return Invisibly returns `.mod`, to enable piping (i.e. from
 #'   `copy_model_from()`)
 #'

--- a/R/test-threads.R
+++ b/R/test-threads.R
@@ -63,14 +63,22 @@ test_threads <- function(
   assert_list(.bbi_args)
 
   # Duplicate model for each thread scenario
-  .mods <- map(.threads, ~ copy_model_from(.mod,
-                                           paste0(get_model_id(.mod), "_", .x, "_threads"),
-                                           .overwrite = TRUE) %>%
-                 add_bbi_args(.bbi_args = c(threads = .x,
-                                            .bbi_args,
-                                            parallel = TRUE,
-                                            overwrite = TRUE)) %>%
-                 add_tags(paste("test threads")))
+  .mods <- map(.threads, function(.x) {
+    copy_model_from(
+      .mod,
+      paste0(get_model_id(.mod), "_", .x, "_threads"),
+      .overwrite = TRUE
+    ) %>%
+      add_bbi_args(
+        .bbi_args = c(
+          threads = .x,
+          .bbi_args,
+          parallel = TRUE,
+          overwrite = TRUE
+        )
+      ) %>%
+      add_tags(paste("test threads"))
+  })
 
   # Modify Estimation Options
   adjust_estimation_options(.mods, .cap_iterations)

--- a/R/test-threads.R
+++ b/R/test-threads.R
@@ -67,7 +67,8 @@ test_threads <- function(
     copy_model_from(
       .mod,
       paste0(get_model_id(.mod), "_", .x, "_threads"),
-      .overwrite = TRUE
+      .overwrite = TRUE,
+      .update_id = FALSE
     ) %>%
       add_bbi_args(
         .bbi_args = c(

--- a/R/vpc-simulation.R
+++ b/R/vpc-simulation.R
@@ -278,6 +278,7 @@ new_sim_model <- function(
     .add_tags = "SIMULATION",
     .inherit_tags = .inherit_tags,
     .update_model_file = TRUE,
+    .update_id = FALSE,
     .overwrite = .overwrite
   )
 

--- a/man/copy_control_stream.Rd
+++ b/man/copy_control_stream.Rd
@@ -19,10 +19,8 @@ copy_control_stream(
 \item{.overwrite}{If \code{TRUE}, overwrite existing file at \code{.new_model_path}. If \code{FALSE} and file exists at \code{.new_model_path} error.}
 
 \item{.update_model_file}{\strong{Only relevant to NONMEM models.} If \code{TRUE}, the
-default, update the newly created model file. If \code{FALSE}, new model file
-will be an exact copy of its parent. For a NONMEM model, this currently
-means only the \verb{$PROBLEM} line in the new control stream will be updated to
-read \verb{See \{.new_model\}.yaml. Created by bbr.}.}
+default, update the newly created model file by setting the \verb{$PROBLEM} line
+in the new control stream to read \verb{See \{.new_model\}.yaml. Created by bbr.}.}
 }
 \description{
 Helper function to copy a NONMEM control stream file and optionally update the new file.

--- a/man/copy_control_stream.Rd
+++ b/man/copy_control_stream.Rd
@@ -18,7 +18,11 @@ copy_control_stream(
 
 \item{.overwrite}{If \code{TRUE}, overwrite existing file at \code{.new_model_path}. If \code{FALSE} and file exists at \code{.new_model_path} error.}
 
-\item{.update_model_file}{If \code{TRUE}, the default, update the \verb{$PROBLEM} line in the new control stream. If \code{FALSE}, \verb{\{.new_model\}.[mod|ctl]} will be an exact copy of its parent control stream.}
+\item{.update_model_file}{\strong{Only relevant to NONMEM models.} If \code{TRUE}, the
+default, update the newly created model file. If \code{FALSE}, new model file
+will be an exact copy of its parent. For a NONMEM model, this currently
+means only the \verb{$PROBLEM} line in the new control stream will be updated to
+read \verb{See \{.new_model\}.yaml. Created by bbr.}.}
 }
 \description{
 Helper function to copy a NONMEM control stream file and optionally update the new file.

--- a/man/copy_model_from.Rd
+++ b/man/copy_model_from.Rd
@@ -14,7 +14,8 @@ copy_model_from(
   .star = NULL,
   .inherit_tags = FALSE,
   .update_model_file = TRUE,
-  .overwrite = FALSE
+  .overwrite = FALSE,
+  ...
 )
 
 \method{copy_model_from}{bbi_nonmem_model}(
@@ -26,7 +27,8 @@ copy_model_from(
   .star = NULL,
   .inherit_tags = FALSE,
   .update_model_file = TRUE,
-  .overwrite = FALSE
+  .overwrite = FALSE,
+  ...
 )
 }
 \arguments{
@@ -66,6 +68,8 @@ read \verb{See \{.new_model\}.yaml. Created by bbr.}.}
 \item{.overwrite}{If \code{FALSE}, the default,  function will error if a model
 file already exists at specified \code{.new_model} path. If \code{TRUE} any existing
 file at \code{.new_model} will be overwritten silently.}
+
+\item{...}{Arguments passed on to methods.}
 }
 \description{
 Create new model by copying existing model. Useful for iterating during model

--- a/man/copy_model_from.Rd
+++ b/man/copy_model_from.Rd
@@ -28,7 +28,8 @@ copy_model_from(
   .inherit_tags = FALSE,
   .update_model_file = TRUE,
   .overwrite = FALSE,
-  ...
+  ...,
+  .update_id = TRUE
 )
 }
 \arguments{
@@ -68,6 +69,11 @@ file already exists at specified \code{.new_model} path. If \code{TRUE} any exis
 file at \code{.new_model} will be overwritten silently.}
 
 \item{...}{Arguments passed on to methods.}
+
+\item{.update_id}{Whether to call \code{\link[=update_model_id]{update_model_id()}} to replace occurrences
+of \verb{\{parent_mod\}.\{suffix\}} with the ID of the new model. To override or
+extend the default suffixes, set this argument to \code{FALSE} and follow up
+with a direct call to \code{\link[=update_model_id]{update_model_id()}}.}
 }
 \description{
 Create new model by copying existing model. Useful for iterating during model

--- a/man/copy_model_from.Rd
+++ b/man/copy_model_from.Rd
@@ -60,10 +60,8 @@ tags passed to \code{.add_tags} argument. If \code{TRUE} inherit any tags from
 \code{.parent_mod}, with any tags passed to \code{.add_tags} appended.}
 
 \item{.update_model_file}{\strong{Only relevant to NONMEM models.} If \code{TRUE}, the
-default, update the newly created model file. If \code{FALSE}, new model file
-will be an exact copy of its parent. For a NONMEM model, this currently
-means only the \verb{$PROBLEM} line in the new control stream will be updated to
-read \verb{See \{.new_model\}.yaml. Created by bbr.}.}
+default, update the newly created model file by setting the \verb{$PROBLEM} line
+in the new control stream to read \verb{See \{.new_model\}.yaml. Created by bbr.}.}
 
 \item{.overwrite}{If \code{FALSE}, the default,  function will error if a model
 file already exists at specified \code{.new_model} path. If \code{TRUE} any existing

--- a/man/copy_model_from_impl.Rd
+++ b/man/copy_model_from_impl.Rd
@@ -14,6 +14,7 @@ copy_model_from_impl(
   .inherit_tags = FALSE,
   .update_model_file = TRUE,
   .overwrite = FALSE,
+  .update_id = TRUE,
   setup_fn = NULL
 )
 }
@@ -52,6 +53,11 @@ in the new control stream to read \verb{See \{.new_model\}.yaml. Created by bbr.
 \item{.overwrite}{If \code{FALSE}, the default,  function will error if a model
 file already exists at specified \code{.new_model} path. If \code{TRUE} any existing
 file at \code{.new_model} will be overwritten silently.}
+
+\item{.update_id}{Whether to call \code{\link[=update_model_id]{update_model_id()}} to replace occurrences
+of \verb{\{parent_mod\}.\{suffix\}} with the ID of the new model. To override or
+extend the default suffixes, set this argument to \code{FALSE} and follow up
+with a direct call to \code{\link[=update_model_id]{update_model_id()}}.}
 
 \item{setup_fn}{A function to call (with no arguments) before creating the
 model with \code{\link[=new_model]{new_model()}}.}

--- a/man/copy_model_from_impl.Rd
+++ b/man/copy_model_from_impl.Rd
@@ -45,10 +45,11 @@ no need to include that here.}
 tags passed to \code{.add_tags} argument. If \code{TRUE} inherit any tags from
 \code{.parent_mod}, with any tags passed to \code{.add_tags} appended.}
 
-\item{.update_model_file}{\strong{Only relevant for NONMEM models.} If \code{TRUE}, the
-default, update the \verb{$PROBLEM} line in the new control stream. If \code{FALSE},
-\verb{\{.new_model\}.[mod|ctl]} will be an exact copy of its parent control
-stream.}
+\item{.update_model_file}{\strong{Only relevant to NONMEM models.} If \code{TRUE}, the
+default, update the newly created model file. If \code{FALSE}, new model file
+will be an exact copy of its parent. For a NONMEM model, this currently
+means only the \verb{$PROBLEM} line in the new control stream will be updated to
+read \verb{See \{.new_model\}.yaml. Created by bbr.}.}
 
 \item{.overwrite}{If \code{FALSE}, the default,  function will error if a model
 file already exists at specified \code{.new_model} path. If \code{TRUE} any existing

--- a/man/copy_model_from_impl.Rd
+++ b/man/copy_model_from_impl.Rd
@@ -46,10 +46,8 @@ tags passed to \code{.add_tags} argument. If \code{TRUE} inherit any tags from
 \code{.parent_mod}, with any tags passed to \code{.add_tags} appended.}
 
 \item{.update_model_file}{\strong{Only relevant to NONMEM models.} If \code{TRUE}, the
-default, update the newly created model file. If \code{FALSE}, new model file
-will be an exact copy of its parent. For a NONMEM model, this currently
-means only the \verb{$PROBLEM} line in the new control stream will be updated to
-read \verb{See \{.new_model\}.yaml. Created by bbr.}.}
+default, update the newly created model file by setting the \verb{$PROBLEM} line
+in the new control stream to read \verb{See \{.new_model\}.yaml. Created by bbr.}.}
 
 \item{.overwrite}{If \code{FALSE}, the default,  function will error if a model
 file already exists at specified \code{.new_model} path. If \code{TRUE} any existing

--- a/man/update_model_id.Rd
+++ b/man/update_model_id.Rd
@@ -60,4 +60,9 @@ All matches are \emph{not} case sensitive but replacements \emph{are}. For examp
 \code{.msf} is passed as a suffix, \verb{\{parent_mod\}.MSF} and \verb{\{parent_mod\}.msf} would
 \emph{both} be replaced, but the case of the suffix in the control stream will be
 maintained as is.
+
+As of bbr 1.15.0, \code{\link[=copy_model_from]{copy_model_from()}} by default calls \code{update_model_id()}
+internally before returning the model. You do not need to call
+\code{update_model_id()} directly unless you want to override or extend the
+default suffixes.
 }

--- a/tests/testthat/helpers-create-example-model.R
+++ b/tests/testthat/helpers-create-example-model.R
@@ -156,7 +156,7 @@ make_fake_boot <- function(mod, n = 100, strat_cols = c("SEX", "ETN")){
 # This function creates a new model, and attaches a simulation to it
 # Unlike make_fake_boot however, the simulation will have a status of "Not Run"
 make_fake_sim <- function(mod, mod_id = "mod-sim", n = 100){
-  mod_sim <- copy_model_from(mod, mod_id) %>% update_model_id()
+  mod_sim <- copy_model_from(mod, mod_id, .update_id = TRUE)
   model_dir <- bbr:::get_model_working_directory(mod)
   new_dir_path <- file.path(model_dir, mod_id)
   fs::dir_copy(mod$absolute_model_path, new_dir_path)

--- a/tests/testthat/setup-workflow-ref.R
+++ b/tests/testthat/setup-workflow-ref.R
@@ -230,13 +230,19 @@ copy_all_output_dirs <- function() {
 create_rlg_models <- function() {
   # copy models before creating run log
   mod1 <- read_model(MOD1_PATH)
-  copy_model_from(mod1, basename(NEW_MOD2), .add_tags = NEW_TAGS)
+  copy_model_from(
+    mod1,
+    basename(NEW_MOD2),
+    .add_tags = NEW_TAGS,
+    .update_id = FALSE
+  )
   copy_model_from(
     mod1,
     basename(NEW_MOD3),
     .based_on_additional = get_model_id(NEW_MOD2),
     .inherit_tags = TRUE,
-    .update_model_file = FALSE
+    .update_model_file = FALSE,
+    .update_id = FALSE
   )
   return(invisible(NULL))
 }

--- a/tests/testthat/test-copy-model-helpers.R
+++ b/tests/testthat/test-copy-model-helpers.R
@@ -152,3 +152,19 @@ test_that("update_model_id() protects regex characters in parent model ID", {
     )
   })
 })
+
+test_that("update_model_id() anchors start of regexp", {
+  withr::with_tempdir({
+    mod1 <- copy_model_from(MOD1, file.path(getwd(), "1"))
+    mod2 <- copy_model_from(mod1, 2)
+    mod2_path <- get_model_path(mod2)
+
+    readr::write_lines(c("11.tab", "1.tab"), mod2_path)
+
+    update_model_id(mod2)
+    expect_identical(
+      readr::read_lines(mod2_path),
+      c("11.tab", "2.tab")
+    )
+  })
+})

--- a/tests/testthat/test-copy-model-helpers.R
+++ b/tests/testthat/test-copy-model-helpers.R
@@ -11,7 +11,7 @@ test_that("update_model_id() works with run number [BBR-CMH-001]", {
   on.exit({ cleanup() })
 
   # copy model and write strings with parent id to control stream
-  new_mod <- copy_model_from(MOD1, basename(NEW_MOD2))
+  new_mod <- copy_model_from(MOD1, basename(NEW_MOD2), .update_id = FALSE)
   readr::write_lines(
     paste0(get_model_id(MOD1), DEFAULT_SUFFIXES),
     get_model_path(new_mod)
@@ -28,8 +28,8 @@ test_that("update_model_id() works with character ID [BBR-CMH-002]", {
   on.exit({ cleanup() })
 
   # copy model and write strings with parent id to control stream
-  parent_mod <- copy_model_from(MOD1, "Parent")
-  new_mod <- copy_model_from(parent_mod, "Child")
+  parent_mod <- copy_model_from(MOD1, "Parent", .update_id = FALSE)
+  new_mod <- copy_model_from(parent_mod, "Child", .update_id = FALSE)
   readr::write_lines(
     paste0(get_model_id(parent_mod), DEFAULT_SUFFIXES),
     get_model_path(new_mod)
@@ -47,7 +47,7 @@ test_that("update_model_id() is case-sensitive [BBR-CMH-003]", {
   suff_all_case <- c(toupper(DEFAULT_SUFFIXES), tolower(DEFAULT_SUFFIXES))
 
   # copy model and write strings with parent id to control stream
-  new_mod <- copy_model_from(MOD1, basename(NEW_MOD2))
+  new_mod <- copy_model_from(MOD1, basename(NEW_MOD2), .update_id = FALSE)
   readr::write_lines(
     paste0(get_model_id(MOD1), suff_all_case),
     get_model_path(new_mod)
@@ -64,7 +64,7 @@ test_that("update_model_id() .suffixes works [BBR-CMH-004]", {
   on.exit({ cleanup() })
 
   # copy model and write strings with parent id to control stream
-  new_mod <- copy_model_from(MOD1, basename(NEW_MOD2))
+  new_mod <- copy_model_from(MOD1, basename(NEW_MOD2), .update_id = FALSE)
   orig_suff <- paste0(get_model_id(MOD1), DEFAULT_SUFFIXES)
 
   readr::write_lines(
@@ -87,7 +87,7 @@ test_that("update_model_id() .additional_suffixes works [BBR-CMH-005]", {
   on.exit({ cleanup() })
 
   # copy model and write strings with parent id to control stream
-  new_mod <- copy_model_from(MOD1, basename(NEW_MOD2))
+  new_mod <- copy_model_from(MOD1, basename(NEW_MOD2), .update_id = FALSE)
   new_suff <- ".naw"
 
   readr::write_lines(
@@ -120,7 +120,8 @@ test_that("update_model_id() works with models in different directories", {
   # copy model and write strings with parent id to control stream
   new_mod <- copy_model_from(
     MOD1,
-    file.path(basename(child_dir), basename(NEW_MOD2))
+    file.path(basename(child_dir), basename(NEW_MOD2)),
+    .update_id = FALSE
   )
   new_suff <- "-1.msf"
 
@@ -139,8 +140,8 @@ test_that("update_model_id() works with models in different directories", {
 
 test_that("update_model_id() protects regex characters in parent model ID", {
   withr::with_tempdir({
-    mod1a <- copy_model_from(MOD1, file.path(getwd(), "1+"))
-    mod2 <- copy_model_from(mod1a, 2)
+    mod1a <- copy_model_from(MOD1, file.path(getwd(), "1+"), .update_id = FALSE)
+    mod2 <- copy_model_from(mod1a, 2, .update_id = FALSE)
 
     mod2_path <- get_model_path(mod2)
     readr::write_lines(c("1+.tab", "11.tab"), mod2_path)
@@ -155,8 +156,8 @@ test_that("update_model_id() protects regex characters in parent model ID", {
 
 test_that("update_model_id() anchors start of regexp", {
   withr::with_tempdir({
-    mod1 <- copy_model_from(MOD1, file.path(getwd(), "1"))
-    mod2 <- copy_model_from(mod1, 2)
+    mod1 <- copy_model_from(MOD1, file.path(getwd(), "1"), .update_id = FALSE)
+    mod2 <- copy_model_from(mod1, 2, .update_id = FALSE)
     mod2_path <- get_model_path(mod2)
 
     readr::write_lines(c("11.tab", "1.tab"), mod2_path)
@@ -171,9 +172,14 @@ test_that("update_model_id() anchors start of regexp", {
 
 test_that("update_model_id() handles multiple based_on values", {
   withr::with_tempdir({
-    mod1 <- copy_model_from(MOD1, file.path(getwd(), "1"))
-    mod2 <- copy_model_from(mod1, 2)
-    mod3 <- copy_model_from(mod2, 3, .based_on_additional = get_model_id(mod1))
+    mod1 <- copy_model_from(MOD1, file.path(getwd(), "1"), .update_id = FALSE)
+    mod2 <- copy_model_from(mod1, 2, .update_id = FALSE)
+    mod3 <- copy_model_from(
+      mod2,
+      3,
+      .based_on_additional = get_model_id(mod1),
+      .update_id = FALSE
+    )
 
     mod3_path <- get_model_path(mod3)
 

--- a/tests/testthat/test-copy-model-helpers.R
+++ b/tests/testthat/test-copy-model-helpers.R
@@ -168,3 +168,21 @@ test_that("update_model_id() anchors start of regexp", {
     )
   })
 })
+
+test_that("update_model_id() handles multiple based_on values", {
+  withr::with_tempdir({
+    mod1 <- copy_model_from(MOD1, file.path(getwd(), "1"))
+    mod2 <- copy_model_from(mod1, 2)
+    mod3 <- copy_model_from(mod2, 3, .based_on_additional = get_model_id(mod1))
+
+    mod3_path <- get_model_path(mod3)
+
+    readr::write_lines(c("1.tab", "2.tab"), mod3_path)
+
+    update_model_id(mod3)
+    expect_identical(
+      readr::read_lines(mod3_path),
+      c("1.tab", "3.tab")
+    )
+  })
+})

--- a/tests/testthat/test-model-status.R
+++ b/tests/testthat/test-model-status.R
@@ -23,7 +23,7 @@ describe("Model status helpers return the correct status", {
   .boot_run <- new_bootstrap_run(MOD1)
 
   # Test simulation - use fake MSF file for model creation
-  mod3 <- copy_model_from(MOD1, "3") %>% update_model_id() %>% add_msf_opt()
+  mod3 <- copy_model_from(MOD1, "3", .update_id = TRUE) %>% add_msf_opt()
   copy_output_dir(MOD1, file.path(MODEL_DIR, "3"))
   msf_path <- get_msf_path(mod3, .check_exists = FALSE)
   writeLines(readLines(nm_table_files(MOD1)[1]), msf_path)

--- a/tests/testthat/test-modify-records.R
+++ b/tests/testthat/test-modify-records.R
@@ -151,7 +151,7 @@ describe("Modify record helpers", {
   })
 
   it("get_table_columns works", {
-    mod2 <- copy_model_from(MOD1, "2")
+    mod2 <- copy_model_from(MOD1, "2", .update_id = FALSE)
     fs::dir_copy(MOD1[[ABS_MOD_PATH]], file.path(MODEL_DIR, "2"))
     on.exit(delete_models(mod2, .tags = NULL, .force = TRUE))
 

--- a/tests/testthat/test-workflow-simulation.R
+++ b/tests/testthat/test-workflow-simulation.R
@@ -86,7 +86,7 @@ withr::with_options(
       # Make an incomplete simulation model for testing the control stream changes
       # - no spec file is generated, so the parent model (mod2) is unaware of its
       #   presence
-      mod2 <- copy_model_from(mod1, "2") %>% update_model_id()
+      mod2 <- copy_model_from(mod1, "2", .update_id = TRUE)
       copy_output_dir(mod1, file.path(MODEL_DIR_BBI, "2"))
       sim_inc <- new_sim_model(
         mod2, n = sim_n, seed = sim_seed,

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -250,11 +250,10 @@ Now you can create a new model object, based on the original, copying and renami
 The `copy_model_from()` call below will create both `2.ctl` and `2.yaml` files in the same directory as the parent model, and return the model object corresponding to them. (`copy_model_from()` also stores the model's "ancestry" which can be useful later in the project, as shown in the [Using the based_on field](https://metrumresearchgroup.github.io/bbr/articles/using-based-on.html) vignette.)
 
 ```{r copy_model 2}
-mod2 <- copy_model_from(mod1) %>%
-  update_model_id()
+mod2 <- copy_model_from(mod1)
 ```
 
-The new control stream file `2.ctl` will be identical to its parent model, though you can use [`update_model_id()`](https://metrumresearchgroup.github.io/bbr/reference/update_model_id.html) (as above) to update to the new model ID in places like `$TABLE` statements. 
+The new control stream file `2.ctl` will be derived from the parent model's, with occurrences of the old model ID will be updated with the new model ID unless the `.update_id` argument is set to `FALSE`.  (For bbr versions before 1.15.0, a follow-up call to [`update_model_id()`](https://metrumresearchgroup.github.io/bbr/reference/update_model_id.html) was required to update the model ID.)
 
 Your new control stream can now be edited with any desired changes and then submitted and summarized exactly as above. At any time, you can also see the difference between a model and its parent using [`model_diff()`](https://metrumresearchgroup.github.io/bbr/reference/model_diff.html).
 

--- a/vignettes/model-tree.Rmd
+++ b/vignettes/model-tree.Rmd
@@ -71,22 +71,21 @@ create_tree_models <- function(MODEL_DIR){
   tags <- c("new tag 1", "new tag 2")
   # copy models before creating model tree
   mod1 <- read_model(MOD1_PATH)
-  mod2 <- copy_model_from(mod1, "2", .overwrite = TRUE, .add_tags = tags) %>% 
-    update_model_id() %>% add_star()
-  mod3 <- copy_model_from(mod2, "3", .overwrite = TRUE, .add_tags = "DV: nmol") %>% 
-    update_model_id()
-  mod4 <- copy_model_from(mod2, "4", .overwrite = TRUE) %>% update_model_id()
-  mod5 <- copy_model_from(mod4, "5", .overwrite = TRUE) %>% update_model_id()
-  
+  mod2 <- copy_model_from(mod1, "2", .overwrite = TRUE, .add_tags = tags, .update_id = TRUE) %>%
+    add_star()
+  mod3 <- copy_model_from(mod2, "3", .overwrite = TRUE, .add_tags = "DV: nmol", .update_id = TRUE)
+  mod4 <- copy_model_from(mod2, "4", .overwrite = TRUE, .update_id = TRUE)
+  mod5 <- copy_model_from(mod4, "5", .overwrite = TRUE, .update_id = TRUE)
+
   # Multiple based_on
   mod6 <- copy_model_from(
     mod5, "6", .overwrite = TRUE, .based_on_additional = c("1", "3"),
-    .star = TRUE, .description = "final model"
-  ) %>% update_model_id() %>% suppressWarnings()
+    .star = TRUE, .description = "final model", .update_id = TRUE
+  ) %>% suppressWarnings()
   mod7 <- copy_model_from(
-    mod6, "7", .overwrite = TRUE, .based_on_additional = c("2")
-  ) %>% update_model_id() %>% suppressWarnings()
-  
+    mod6, "7", .overwrite = TRUE, .based_on_additional = c("2"), .update_id = TRUE
+  ) %>% suppressWarnings()
+
   # Fake runs
   copy_output_dir(mod1, mod2)
   copy_output_dir(mod1, mod3)


### PR DESCRIPTION
In gh-758 @callistosp suggested that by default `copy_model_from` should call `update_model_id` underneath, allowing the behavior to be disabled via an argument.

This series makes that update, with the primary change in 1757de9f (copy_model_from.bbi_nonmem_model: add .update_id argument).

----

bbr.bayes needs to be adjusted for compatibility.  I'll leave this PR as a draft until the bbr.bayes PR is up too.