### PR TITLE
Prepare 1.15.0 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr
 Title: R package for bbi
-Version: 1.14.3
+Version: 1.15.0
 Authors@R: 
     c(person(given = "Seth",
              family = "Green",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+# bbr 1.15.0
+
+## New features and changes
+
+- `copy_model_from()` now calls `update_model_id()` underneath by default.  To
+  restore the previous behavior, set the new `.update_id` argument to
+  `FALSE`. (#761)
+
+- `bbr` has been updated for compatibility with readr 2.0.0, which is now the
+  minimum required version. (#759)
+
+## Bug fixes
+
+- `update_model_id()` no longer updates occurrences of the parent ID that are
+  embedded in a larger "word". (#761)
+
+
 # bbr 1.14.3
 
 ## Changes


### PR DESCRIPTION
changeset: [1.14.3...release/1.15.0](https://github.com/metrumresearchgroup/bbr/compare/1.14.3...release/1.15.0)

<details>
<summary>scores</summary>

```
$ git rev-parse HEAD^{tree}
cc27a588cd30bd73e740b333695cc1bd209569ff
```

```json
{
  "testing": {
    "check": 1,
    "coverage": 0.8385
  },
  "documentation": {
    "has_vignettes": 1,
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```

</details>
