### PR TITLE
Support overriding column names for NUM and ID

### DIFF
--- a/R/bbr.R
+++ b/R/bbr.R
@@ -42,6 +42,9 @@
 #' * `bbr.verbose` -- set to `FALSE` to limit informational messages output by
 #'   some functions
 #'
+#' * `mrg.num_col` -- the default column name to use when joining table files
+#'    (see [nm_join()])
+#'
 #' @importFrom glue glue
 #' @importFrom rlang .data :=
 #' @importFrom lifecycle deprecated deprecate_warn deprecate_stop

--- a/R/bbr.R
+++ b/R/bbr.R
@@ -27,6 +27,21 @@
 #'   metadata, information, and diagnostics about the models. See the following
 #'   help pages for more information: [run_log()] [summary_log()] [config_log()]
 #'
+#' @section Package options:
+#'
+#' * `bbr.bbi_exe_mode` -- default `.mode` value to pass to [submit_model()]
+#'
+#' * `bbr.bbi_exe_path` -- the location of the bbi executable
+#'
+#' * `bbr.gitignore_sim` -- default `gitignore_sim` value passed to
+#'   [add_simulation()]
+#'
+#' * `bbr.strict` -- set to `FALSE` to demote certain issues, such as the model
+#'   YAML file missing required keys, from errors to warnings
+#'
+#' * `bbr.verbose` -- set to `FALSE` to limit informational messages output by
+#'   some functions
+#'
 #' @importFrom glue glue
 #' @importFrom rlang .data :=
 #' @importFrom lifecycle deprecated deprecate_warn deprecate_stop

--- a/R/bbr.R
+++ b/R/bbr.R
@@ -42,6 +42,9 @@
 #' * `bbr.verbose` -- set to `FALSE` to limit informational messages output by
 #'   some functions
 #'
+#' * `mrg.id_col` -- the default column name to take as the subject identifier
+#'    (see [nm_join()])
+#'
 #' * `mrg.num_col` -- the default column name to use when joining table files
 #'    (see [nm_join()])
 #'

--- a/R/bootstrap-model.R
+++ b/R/bootstrap-model.R
@@ -105,6 +105,8 @@ new_bootstrap_run <- function(
 #' bootstrap run. Once all models have finished, use [summarize_bootstrap_run()]
 #' to view the results. See examples below.
 #'
+#' By default, this function looks for the subject identifier in the "ID"
+#' column. Set the `mrg.id_col` option to use a different column.
 #'
 #' @seealso [new_bootstrap_run()] [summarize_bootstrap_run()] [submit_model()]
 #'
@@ -340,13 +342,15 @@ make_boot_run <- function(mod_path, boot_args){
   )
 
 
+  # TODO: should this be a user arg?
+  id_col <- getOption("mrg.id_col")
   # Sample data and assign new IDs
   data_new <- mrgmisc::resample_df(
     boot_args$orig_data,
-    key_cols = "ID", # TODO: should this be a user arg?
+    key_cols = id_col,
     strat_cols = boot_args$strat_cols,
     replace = TRUE
-  ) %>% dplyr::rename("OID" = "ID", "ID" = "KEY") %>% # TODO: should this be a user arg?
+  ) %>% dplyr::rename("OID" = all_of(id_col), !!id_col := "KEY") %>%
     dplyr::select(all_of(unique(c(names(boot_args$orig_data), "OID"))))
 
   mod_name <- basename(mod_path)

--- a/R/nm-join.R
+++ b/R/nm-join.R
@@ -175,11 +175,13 @@ nm_join_impl <- function(
   nid <-  .s$run_details$number_of_subjects
   nrec <- .s$run_details$number_of_data_records
 
+  id_col <- getOption("mrg.id_col")
+
   # do the join(s)
   if(!is.null(.tbls)){
     for (.n in names(.tbls)) {
       tab <- .tbls[[.n]]
-      has_id <- "ID" %in% names(tab)
+      has_id <- id_col %in% names(tab)
 
       if (!(nrow(tab) %in% c(nrec, nid))) {
         # skip table if nrow doesn't match number of records or ID's
@@ -193,16 +195,16 @@ nm_join_impl <- function(
         # if ID is missing, get it from the data by using .join_col
         if (!has_id) {
           tab <- tab %>%
-            left_join(select(.d, "ID", !!.join_col), by = .join_col)
+            left_join(select(.d, all_of(id_col), !!.join_col), by = .join_col)
         }
 
         # toss .join_col, if present, because we're joining on ID
         tab[[.join_col]] <- NULL
 
         # do the join
-        tab <- drop_dups(tab, .d, "ID", .n)
+        tab <- drop_dups(tab, .d, id_col, .n)
         col_order <- union(col_order, names(tab))
-        .d <- join_first_only_fun(tab, .d, by = "ID")
+        .d <- join_first_only_fun(tab, .d, by = id_col)
       } else if (nrow(tab) == nrec) {
         # otherwise, join on .join_col
         tab <- drop_dups(tab, .d, .join_col, .n)

--- a/R/nm-join.R
+++ b/R/nm-join.R
@@ -13,8 +13,9 @@
 #' FALSE)`.
 #'
 #' @inheritParams nm_tables
-#' @param .join_col Character column name to use to join table files. Defaults to
-#'   `NUM`. See Details.
+#' @param .join_col Character column name to use to join table files. Defaults
+#'   to "NUM", unless the `mrg.num_col` option is set to another value. See
+#'   Details.
 #' @param .superset If `FALSE`, the default, the data will be joined to the
 #'   NONMEM output and if `TRUE`, the NONMEM output will be joined to the data;
 #'   that is, if you use `.superset`, you will get the same number of rows as
@@ -66,7 +67,7 @@
 #' @export
 nm_join <- function(
     .mod,
-    .join_col = "NUM",
+    .join_col = getOption("mrg.num_col"),
     .files = nm_table_files(.mod),
     .superset = FALSE,
     .bbi_args = list(
@@ -106,7 +107,7 @@ nm_join <- function(
 #' @keywords internal
 nm_join_impl <- function(
     .mod,
-    .join_col = "NUM",
+    .join_col = getOption("mrg.num_col"),
     .files = nm_table_files(.mod),
     .superset = FALSE,
     .bbi_args = list(
@@ -253,7 +254,8 @@ drop_dups <- function(.new_table, .dest_table, .join_col, .table_name) {
 #' @param .mod A `bbi_nonmem_model` with an attached simulation, or a
 #'  `bbi_nmsim_model` object.
 #' @param .join_col Character column name(s) to use to join table files.
-#'  Defaults to `NUM`. See Details.
+#'  Defaults to "NUM", unless the `mrg.num_col` option is set to another value.
+#'  See Details.
 #' @param .cols_keep Either `'all'`, or a vector of column name(s) to retain
 #'  in the final dataset after joining. Defaults to keeping all columns.
 #' @inheritParams nm_file_multi_tab
@@ -284,7 +286,7 @@ drop_dups <- function(.new_table, .dest_table, .join_col, .table_name) {
 #' @export
 nm_join_sim <- function(
     .mod,
-    .join_col = "NUM",
+    .join_col = getOption("mrg.num_col"),
     .cols_keep = "all",
     add_table_names = FALSE
 ){

--- a/R/vpc-simulation.R
+++ b/R/vpc-simulation.R
@@ -84,7 +84,7 @@ add_simulation <- function(
     data = NULL,
     sim_cols = c("DV", "PRED"),
     gitignore_sim = getOption("bbr.gitignore_sim"),
-    .join_col = "NUM",
+    .join_col = getOption("mrg.num_col"),
     .inherit_tags = TRUE,
     .bbi_args = NULL,
     .mode = getOption("bbr.bbi_exe_mode"),
@@ -210,7 +210,8 @@ get_simulation <- function(.mod){
 #'  table out.
 #' @param .join_col Character column name(s) used to join table files post
 #'  execution. Gets appended to the generated `$TABLE` record. See
-#'  [nm_join_sim()] documentation for details. Defaults to `'NUM'`.
+#'  [nm_join_sim()] documentation for details. Defaults to the "NUM", unless the
+#'  `mrg.num_col` option is set to another value.
 #' @param gitignore_sim If `TRUE`, the default, add the simulation output directory
 #'  to a `.gitignore` file. The intention here is to avoid committing large files
 #'  (i.e. large simulation tables). This can be passed directly to this argument
@@ -254,7 +255,7 @@ new_sim_model <- function(
     data = NULL,
     sim_cols = c("DV", "PRED"),
     gitignore_sim = getOption("bbr.gitignore_sim"),
-    .join_col = "NUM",
+    .join_col = getOption("mrg.num_col"),
     .sim_dir = get_output_dir(.mod),
     .inherit_tags = TRUE,
     .overwrite = FALSE
@@ -368,7 +369,7 @@ setup_sim_run <- function(
     n = 100,
     seed = 1234,
     sim_cols = c("DV", "PRED"),
-    .join_col = c("NUM")
+    .join_col = getOption("mrg.num_col")
 ){
   check_model_object(.mod, c(NM_MOD_CLASS, NMSIM_MOD_CLASS))
   checkmate::assert_numeric(n, lower = 1)
@@ -424,7 +425,7 @@ setup_sim_run <- function(
 #' @inheritParams new_sim_model
 #' @returns `TRUE` invisibly
 #' @keywords internal
-check_model_for_sim <- function(.mod, .join_col = "NUM"){
+check_model_for_sim <- function(.mod, .join_col = getOption("mrg.num_col")){
 
   # Check the MSF file in $EST
   msf_path <- get_msf_path(.mod, .check_exists = FALSE)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -42,6 +42,10 @@
     options("bbr.gitignore_sim" = TRUE)
   }
 
+  if (is.null(getOption("mrg.id_col"))) {
+    options("mrg.id_col" = "ID")
+  }
+
   if (is.null(getOption("mrg.num_col"))) {
     options("mrg.num_col" = "NUM")
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -42,6 +42,9 @@
     options("bbr.gitignore_sim" = TRUE)
   }
 
+  if (is.null(getOption("mrg.num_col"))) {
+    options("mrg.num_col" = "NUM")
+  }
 }
 
 .onAttach <- function(libname, pkgname) {

--- a/man-roxygen/nm-join-col-firstonly.R
+++ b/man-roxygen/nm-join-col-firstonly.R
@@ -4,7 +4,8 @@
 #'     same number of rows as the there are individuals in the input data set
 #'     (accounting for any filtering of data in the NONMEM control stream), it
 #'     will assumed to be a `FIRSTONLY` table. In this case, the table will be
-#'     joined to the input data by the `ID` column. If `ID` is not present in
-#'     the table, it will be using `.join_col`. Note that if _neither_ `ID` or
-#'     the column passed to `.join_col` are present in the table, the join will
+#'     joined to the input data by the name given by the `mrg.id_col` option
+#'     ("ID" by default). If that column is not present in the table, it will be
+#'     using `.join_col`. Note that if _neither_ the `mrg.id_col` column or the
+#'     column passed to `.join_col` are present in the table, the join will
 #'     fail.

--- a/man/bbr.Rd
+++ b/man/bbr.Rd
@@ -45,6 +45,8 @@ help pages for more information: \code{\link[=run_log]{run_log()}} \code{\link[=
 YAML file missing required keys, from errors to warnings
 \item \code{bbr.verbose} -- set to \code{FALSE} to limit informational messages output by
 some functions
+\item \code{mrg.id_col} -- the default column name to take as the subject identifier
+(see \code{\link[=nm_join]{nm_join()}})
 \item \code{mrg.num_col} -- the default column name to use when joining table files
 (see \code{\link[=nm_join]{nm_join()}})
 }

--- a/man/bbr.Rd
+++ b/man/bbr.Rd
@@ -45,6 +45,8 @@ help pages for more information: \code{\link[=run_log]{run_log()}} \code{\link[=
 YAML file missing required keys, from errors to warnings
 \item \code{bbr.verbose} -- set to \code{FALSE} to limit informational messages output by
 some functions
+\item \code{mrg.num_col} -- the default column name to use when joining table files
+(see \code{\link[=nm_join]{nm_join()}})
 }
 }
 

--- a/man/bbr.Rd
+++ b/man/bbr.Rd
@@ -34,6 +34,20 @@ metadata, information, and diagnostics about the models. See the following
 help pages for more information: \code{\link[=run_log]{run_log()}} \code{\link[=summary_log]{summary_log()}} \code{\link[=config_log]{config_log()}}
 }
 }
+\section{Package options}{
+
+\itemize{
+\item \code{bbr.bbi_exe_mode} -- default \code{.mode} value to pass to \code{\link[=submit_model]{submit_model()}}
+\item \code{bbr.bbi_exe_path} -- the location of the bbi executable
+\item \code{bbr.gitignore_sim} -- default \code{gitignore_sim} value passed to
+\code{\link[=add_simulation]{add_simulation()}}
+\item \code{bbr.strict} -- set to \code{FALSE} to demote certain issues, such as the model
+YAML file missing required keys, from errors to warnings
+\item \code{bbr.verbose} -- set to \code{FALSE} to limit informational messages output by
+some functions
+}
+}
+
 \seealso{
 Useful links:
 \itemize{

--- a/man/check_model_for_sim.Rd
+++ b/man/check_model_for_sim.Rd
@@ -4,14 +4,15 @@
 \alias{check_model_for_sim}
 \title{Check that a \code{bbr} model can be used for simulation}
 \usage{
-check_model_for_sim(.mod, .join_col = "NUM")
+check_model_for_sim(.mod, .join_col = getOption("mrg.num_col"))
 }
 \arguments{
 \item{.mod}{a \code{bbi_nonmem_model} object.}
 
 \item{.join_col}{Character column name(s) used to join table files post
 execution. Gets appended to the generated \verb{$TABLE} record. See
-\code{\link[=nm_join_sim]{nm_join_sim()}} documentation for details. Defaults to \code{'NUM'}.}
+\code{\link[=nm_join_sim]{nm_join_sim()}} documentation for details. Defaults to the "NUM", unless the
+\code{mrg.num_col} option is set to another value.}
 }
 \value{
 \code{TRUE} invisibly

--- a/man/new_sim_model.Rd
+++ b/man/new_sim_model.Rd
@@ -12,7 +12,7 @@ new_sim_model(
   data = NULL,
   sim_cols = c("DV", "PRED"),
   gitignore_sim = getOption("bbr.gitignore_sim"),
-  .join_col = "NUM",
+  .join_col = getOption("mrg.num_col"),
   .sim_dir = get_output_dir(.mod),
   .inherit_tags = TRUE,
   .overwrite = FALSE
@@ -42,7 +42,8 @@ or set globally with \code{options("bbr.gitignore_sim")}.}
 
 \item{.join_col}{Character column name(s) used to join table files post
 execution. Gets appended to the generated \verb{$TABLE} record. See
-\code{\link[=nm_join_sim]{nm_join_sim()}} documentation for details. Defaults to \code{'NUM'}.}
+\code{\link[=nm_join_sim]{nm_join_sim()}} documentation for details. Defaults to the "NUM", unless the
+\code{mrg.num_col} option is set to another value.}
 
 \item{.sim_dir}{A directory for holding the new simulation model. Defaults to
 the output directory of \code{.mod}.}

--- a/man/nm_join.Rd
+++ b/man/nm_join.Rd
@@ -6,7 +6,7 @@
 \usage{
 nm_join(
   .mod,
-  .join_col = "NUM",
+  .join_col = getOption("mrg.num_col"),
   .files = nm_table_files(.mod),
   .superset = FALSE,
   .bbi_args = list(no_grd_file = TRUE, no_shk_file = TRUE)
@@ -16,8 +16,9 @@ nm_join(
 \item{.mod}{A \code{bbi_nonmem_model} or \code{bbi_nonmem_summary} object, or a path to
 a NONMEM run.}
 
-\item{.join_col}{Character column name to use to join table files. Defaults to
-\code{NUM}. See Details.}
+\item{.join_col}{Character column name to use to join table files. Defaults
+to "NUM", unless the \code{mrg.num_col} option is set to another value. See
+Details.}
 
 \item{.files}{Character vector of file paths to table files to read in.
 Defaults to calling \code{\link[=nm_table_files]{nm_table_files()}} on \code{.mod}, which will parse all file

--- a/man/nm_join.Rd
+++ b/man/nm_join.Rd
@@ -66,9 +66,10 @@ be unambiguous matching from the table file back to the input data set.
 same number of rows as the there are individuals in the input data set
 (accounting for any filtering of data in the NONMEM control stream), it
 will assumed to be a \code{FIRSTONLY} table. In this case, the table will be
-joined to the input data by the \code{ID} column. If \code{ID} is not present in
-the table, it will be using \code{.join_col}. Note that if \emph{neither} \code{ID} or
-the column passed to \code{.join_col} are present in the table, the join will
+joined to the input data by the name given by the \code{mrg.id_col} option
+("ID" by default). If that column is not present in the table, it will be
+using \code{.join_col}. Note that if \emph{neither} the \code{mrg.id_col} column or the
+column passed to \code{.join_col} are present in the table, the join will
 fail.
 }
 

--- a/man/nm_join_impl.Rd
+++ b/man/nm_join_impl.Rd
@@ -54,9 +54,10 @@ be unambiguous matching from the table file back to the input data set.
 same number of rows as the there are individuals in the input data set
 (accounting for any filtering of data in the NONMEM control stream), it
 will assumed to be a \code{FIRSTONLY} table. In this case, the table will be
-joined to the input data by the \code{ID} column. If \code{ID} is not present in
-the table, it will be using \code{.join_col}. Note that if \emph{neither} \code{ID} or
-the column passed to \code{.join_col} are present in the table, the join will
+joined to the input data by the name given by the \code{mrg.id_col} option
+("ID" by default). If that column is not present in the table, it will be
+using \code{.join_col}. Note that if \emph{neither} the \code{mrg.id_col} column or the
+column passed to \code{.join_col} are present in the table, the join will
 fail.
 }
 

--- a/man/nm_join_impl.Rd
+++ b/man/nm_join_impl.Rd
@@ -6,7 +6,7 @@
 \usage{
 nm_join_impl(
   .mod,
-  .join_col = "NUM",
+  .join_col = getOption("mrg.num_col"),
   .files = nm_table_files(.mod),
   .superset = FALSE,
   .bbi_args = list(no_grd_file = TRUE, no_shk_file = TRUE)
@@ -16,8 +16,9 @@ nm_join_impl(
 \item{.mod}{A \code{bbi_nonmem_model} or \code{bbi_nonmem_summary} object, or a path to
 a NONMEM run.}
 
-\item{.join_col}{Character column name to use to join table files. Defaults to
-\code{NUM}. See Details.}
+\item{.join_col}{Character column name to use to join table files. Defaults
+to "NUM", unless the \code{mrg.num_col} option is set to another value. See
+Details.}
 
 \item{.files}{Character vector of file paths to table files to read in.
 Defaults to calling \code{\link[=nm_table_files]{nm_table_files()}} on \code{.mod}, which will parse all file

--- a/man/nm_join_sim.Rd
+++ b/man/nm_join_sim.Rd
@@ -6,7 +6,7 @@
 \usage{
 nm_join_sim(
   .mod,
-  .join_col = "NUM",
+  .join_col = getOption("mrg.num_col"),
   .cols_keep = "all",
   add_table_names = FALSE
 )
@@ -16,7 +16,8 @@ nm_join_sim(
 \code{bbi_nmsim_model} object.}
 
 \item{.join_col}{Character column name(s) to use to join table files.
-Defaults to \code{NUM}. See Details.}
+Defaults to "NUM", unless the \code{mrg.num_col} option is set to another value.
+See Details.}
 
 \item{.cols_keep}{Either \code{'all'}, or a vector of column name(s) to retain
 in the final dataset after joining. Defaults to keeping all columns.}

--- a/man/setup_bootstrap_run.Rd
+++ b/man/setup_bootstrap_run.Rd
@@ -50,6 +50,9 @@ Once you have run this function, you can execute your bootstrap with
 \code{\link[=submit_model]{submit_model()}}. You can use \code{\link[=get_model_status]{get_model_status()}} to check on your submitted
 bootstrap run. Once all models have finished, use \code{\link[=summarize_bootstrap_run]{summarize_bootstrap_run()}}
 to view the results. See examples below.
+
+By default, this function looks for the subject identifier in the "ID"
+column. Set the \code{mrg.id_col} option to use a different column.
 }
 \examples{
 \dontrun{

--- a/man/setup_sim_run.Rd
+++ b/man/setup_sim_run.Rd
@@ -9,7 +9,7 @@ setup_sim_run(
   n = 100,
   seed = 1234,
   sim_cols = c("DV", "PRED"),
-  .join_col = c("NUM")
+  .join_col = getOption("mrg.num_col")
 )
 }
 \arguments{
@@ -25,7 +25,8 @@ table out.}
 
 \item{.join_col}{Character column name(s) used to join table files post
 execution. Gets appended to the generated \verb{$TABLE} record. See
-\code{\link[=nm_join_sim]{nm_join_sim()}} documentation for details. Defaults to \code{'NUM'}.}
+\code{\link[=nm_join_sim]{nm_join_sim()}} documentation for details. Defaults to the "NUM", unless the
+\code{mrg.num_col} option is set to another value.}
 }
 \description{
 Removes relevant record types, creates new \verb{$SIMULATION} and \verb{$MSFI} records,

--- a/man/simulate.Rd
+++ b/man/simulate.Rd
@@ -14,7 +14,7 @@ add_simulation(
   data = NULL,
   sim_cols = c("DV", "PRED"),
   gitignore_sim = getOption("bbr.gitignore_sim"),
-  .join_col = "NUM",
+  .join_col = getOption("mrg.num_col"),
   .inherit_tags = TRUE,
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
@@ -51,7 +51,8 @@ or set globally with \code{options("bbr.gitignore_sim")}.}
 
 \item{.join_col}{Character column name(s) used to join table files post
 execution. Gets appended to the generated \verb{$TABLE} record. See
-\code{\link[=nm_join_sim]{nm_join_sim()}} documentation for details. Defaults to \code{'NUM'}.}
+\code{\link[=nm_join_sim]{nm_join_sim()}} documentation for details. Defaults to the "NUM", unless the
+\code{mrg.num_col} option is set to another value.}
 
 \item{.inherit_tags}{If \code{TRUE}, the default, inherit any tags from \code{.mod}.}
 

--- a/tests/testthat/test-nm-join.R
+++ b/tests/testthat/test-nm-join.R
@@ -164,6 +164,60 @@ test_that("nm_join(.join_col) works correctly with duplicate cols  [BBR-NMJ-005]
   expect_equal(test_df$NUM, test_df$BUM)
 })
 
+test_that("nm_join works with custom ID and NUM columns", {
+  tdir <- withr::local_tempdir(pattern = "bbr-tests-")
+  withr::local_dir(tdir)
+
+  fs::dir_copy(
+    system.file("extdata", package = "bbr", mustWork = TRUE),
+    "."
+  )
+
+  mdir <- file.path("model", "nonmem", "basic")
+  fs::dir_create(mdir)
+
+  src_path <- system.file(mdir, "1", package = "bbr", mustWork = TRUE)
+  fs::dir_copy(src_path, mdir)
+  fs::file_copy(paste0(src_path, c(".yaml", ".ctl")), mdir)
+
+  edit_file <- function(f, pat, repl) {
+    data <- readChar(f, file.size(f))
+    new <- sub(pat, repl, data, fixed = TRUE)
+    cat(new, file = f)
+  }
+
+  edit_file(file.path("extdata", "acop.csv"), "id", "altid")
+  edit_file(file.path("extdata", "acop.csv"), "num", "altnum")
+
+  for (f in c("1first1.tab", "1first3.tab")) {
+    edit_file(
+      file.path("model", "nonmem", "basic", "1", f),
+      "ID",
+      "ALTID"
+    )
+  }
+
+  for (f in c("1first2.tab", "1par.tab", "1first3.tab", "1.tab", "1dups.tab")) {
+    edit_file(
+      file.path("model", "nonmem", "basic", "1", f),
+      "NUM",
+      "ALTNUM"
+    )
+  }
+
+  mod <- bbr::read_model(file.path(mdir, "1"))
+
+  expect_error(nm_join(mod), "couldn't find")
+
+  withr::local_options(list(
+    "mrg.id_col" = "ALTID",
+    "mrg.num_col" = "ALTNUM"
+  ))
+
+  res <- nm_join(mod)
+  expect_equal(nrow(res), DATA_TEST_ROWS_IGNORE)
+})
+
 ########################
 # warnings and messages
 


### PR DESCRIPTION
"NUM and "ID" are used as columns names in a few spots.  NUM can be overridden via a function argument, while ID is hard coded.  For convenience, allow callers to set the defaults for both names via options.

Use the "mrg." prefix, following the recent changes in [pmtables](https://github.com/metrumresearchgroup/pmtables/pull/380) and [pmplots](https://github.com/metrumresearchgroup/pmplots/pull/124) to support setting the name for the ID column via the `mrg.id_col` option.

---

- [x] wait for base PR to merge (gh-763)