### PR TITLE
options: don't set mrg.id_col and mrg.num_col

### DIFF
--- a/R/bootstrap-model.R
+++ b/R/bootstrap-model.R
@@ -343,7 +343,7 @@ make_boot_run <- function(mod_path, boot_args){
 
 
   # TODO: should this be a user arg?
-  id_col <- getOption("mrg.id_col")
+  id_col <- getOption("mrg.id_col", "ID")
   # Sample data and assign new IDs
   data_new <- mrgmisc::resample_df(
     boot_args$orig_data,

--- a/R/nm-join.R
+++ b/R/nm-join.R
@@ -67,7 +67,7 @@
 #' @export
 nm_join <- function(
     .mod,
-    .join_col = getOption("mrg.num_col"),
+    .join_col = getOption("mrg.num_col", "NUM"),
     .files = nm_table_files(.mod),
     .superset = FALSE,
     .bbi_args = list(
@@ -107,7 +107,7 @@ nm_join <- function(
 #' @keywords internal
 nm_join_impl <- function(
     .mod,
-    .join_col = getOption("mrg.num_col"),
+    .join_col = getOption("mrg.num_col", "NUM"),
     .files = nm_table_files(.mod),
     .superset = FALSE,
     .bbi_args = list(
@@ -175,7 +175,7 @@ nm_join_impl <- function(
   nid <-  .s$run_details$number_of_subjects
   nrec <- .s$run_details$number_of_data_records
 
-  id_col <- getOption("mrg.id_col")
+  id_col <- getOption("mrg.id_col", "ID")
 
   # do the join(s)
   if(!is.null(.tbls)){
@@ -288,7 +288,7 @@ drop_dups <- function(.new_table, .dest_table, .join_col, .table_name) {
 #' @export
 nm_join_sim <- function(
     .mod,
-    .join_col = getOption("mrg.num_col"),
+    .join_col = getOption("mrg.num_col", "NUM"),
     .cols_keep = "all",
     add_table_names = FALSE
 ){

--- a/R/vpc-simulation.R
+++ b/R/vpc-simulation.R
@@ -84,7 +84,7 @@ add_simulation <- function(
     data = NULL,
     sim_cols = c("DV", "PRED"),
     gitignore_sim = getOption("bbr.gitignore_sim"),
-    .join_col = getOption("mrg.num_col"),
+    .join_col = getOption("mrg.num_col", "NUM"),
     .inherit_tags = TRUE,
     .bbi_args = NULL,
     .mode = getOption("bbr.bbi_exe_mode"),
@@ -255,7 +255,7 @@ new_sim_model <- function(
     data = NULL,
     sim_cols = c("DV", "PRED"),
     gitignore_sim = getOption("bbr.gitignore_sim"),
-    .join_col = getOption("mrg.num_col"),
+    .join_col = getOption("mrg.num_col", "NUM"),
     .sim_dir = get_output_dir(.mod),
     .inherit_tags = TRUE,
     .overwrite = FALSE
@@ -369,7 +369,7 @@ setup_sim_run <- function(
     n = 100,
     seed = 1234,
     sim_cols = c("DV", "PRED"),
-    .join_col = getOption("mrg.num_col")
+    .join_col = getOption("mrg.num_col", "NUM")
 ){
   check_model_object(.mod, c(NM_MOD_CLASS, NMSIM_MOD_CLASS))
   checkmate::assert_numeric(n, lower = 1)
@@ -425,7 +425,7 @@ setup_sim_run <- function(
 #' @inheritParams new_sim_model
 #' @returns `TRUE` invisibly
 #' @keywords internal
-check_model_for_sim <- function(.mod, .join_col = getOption("mrg.num_col")){
+check_model_for_sim <- function(.mod, .join_col = getOption("mrg.num_col", "NUM")){
 
   # Check the MSF file in $EST
   msf_path <- get_msf_path(.mod, .check_exists = FALSE)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -41,14 +41,6 @@
   if (is.null(getOption("bbr.gitignore_sim"))) {
     options("bbr.gitignore_sim" = TRUE)
   }
-
-  if (is.null(getOption("mrg.id_col"))) {
-    options("mrg.id_col" = "ID")
-  }
-
-  if (is.null(getOption("mrg.num_col"))) {
-    options("mrg.num_col" = "NUM")
-  }
 }
 
 .onAttach <- function(libname, pkgname) {

--- a/man/check_model_for_sim.Rd
+++ b/man/check_model_for_sim.Rd
@@ -4,7 +4,7 @@
 \alias{check_model_for_sim}
 \title{Check that a \code{bbr} model can be used for simulation}
 \usage{
-check_model_for_sim(.mod, .join_col = getOption("mrg.num_col"))
+check_model_for_sim(.mod, .join_col = getOption("mrg.num_col", "NUM"))
 }
 \arguments{
 \item{.mod}{a \code{bbi_nonmem_model} object.}

--- a/man/new_sim_model.Rd
+++ b/man/new_sim_model.Rd
@@ -12,7 +12,7 @@ new_sim_model(
   data = NULL,
   sim_cols = c("DV", "PRED"),
   gitignore_sim = getOption("bbr.gitignore_sim"),
-  .join_col = getOption("mrg.num_col"),
+  .join_col = getOption("mrg.num_col", "NUM"),
   .sim_dir = get_output_dir(.mod),
   .inherit_tags = TRUE,
   .overwrite = FALSE

--- a/man/nm_join.Rd
+++ b/man/nm_join.Rd
@@ -6,7 +6,7 @@
 \usage{
 nm_join(
   .mod,
-  .join_col = getOption("mrg.num_col"),
+  .join_col = getOption("mrg.num_col", "NUM"),
   .files = nm_table_files(.mod),
   .superset = FALSE,
   .bbi_args = list(no_grd_file = TRUE, no_shk_file = TRUE)

--- a/man/nm_join_impl.Rd
+++ b/man/nm_join_impl.Rd
@@ -6,7 +6,7 @@
 \usage{
 nm_join_impl(
   .mod,
-  .join_col = getOption("mrg.num_col"),
+  .join_col = getOption("mrg.num_col", "NUM"),
   .files = nm_table_files(.mod),
   .superset = FALSE,
   .bbi_args = list(no_grd_file = TRUE, no_shk_file = TRUE)

--- a/man/nm_join_sim.Rd
+++ b/man/nm_join_sim.Rd
@@ -6,7 +6,7 @@
 \usage{
 nm_join_sim(
   .mod,
-  .join_col = getOption("mrg.num_col"),
+  .join_col = getOption("mrg.num_col", "NUM"),
   .cols_keep = "all",
   add_table_names = FALSE
 )

--- a/man/setup_sim_run.Rd
+++ b/man/setup_sim_run.Rd
@@ -9,7 +9,7 @@ setup_sim_run(
   n = 100,
   seed = 1234,
   sim_cols = c("DV", "PRED"),
-  .join_col = getOption("mrg.num_col")
+  .join_col = getOption("mrg.num_col", "NUM")
 )
 }
 \arguments{

--- a/man/simulate.Rd
+++ b/man/simulate.Rd
@@ -14,7 +14,7 @@ add_simulation(
   data = NULL,
   sim_cols = c("DV", "PRED"),
   gitignore_sim = getOption("bbr.gitignore_sim"),
-  .join_col = getOption("mrg.num_col"),
+  .join_col = getOption("mrg.num_col", "NUM"),
   .inherit_tags = TRUE,
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),


### PR DESCRIPTION
bbr sets the default values of many options via .onLoad.  The recent commits that wired up the mrg.num_col and mrg.id_col options followed the same pattern (632e1248, 25ac6c1c).  However, these two options are shared across several packages, so it's confusing for bbr to set them.

Instead inline the fallback value for each getOption call.