### PR TITLE
submit model: `.mode` guard updates

### DIFF
--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -373,7 +373,10 @@ check_mode_argument <- function(.mode) {
   if (identical(.mode, "sge")) {
     qsub <- normalizePath(unname(Sys.which("qsub")), mustWork = FALSE)
     if (identical(qsub, "")) {
-      stop(".mode='sge' but qsub is not available on system")
+      stop(
+        ".mode='sge' but qsub is not available",
+        "; use .mode='local' on system without grid scheduler"
+      )
     }
 
     # This guard is Metworx (or really ParallelCluster) specific. Slurm ships

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -391,6 +391,16 @@ check_mode_argument <- function(.mode) {
     }
   }
 
+  if (identical(.mode, "slurm")) {
+    sbatch <- normalizePath(unname(Sys.which("sbatch")), mustWork = FALSE)
+    if (identical(sbatch, "")) {
+      stop(
+        ".mode='slurm' but sbatch is not available",
+        "; use .mode='local' on system without grid scheduler"
+      )
+    }
+  }
+
   return(invisible(TRUE))
 }
 

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -117,9 +117,13 @@ test_that("submit_model(.mode) errors when invalid", {
 test_that("submit_model aborts if .mode='sge' is used with Slurm's qsub", {
   skip_if_old_bbi("3.4.0")
 
-  sbatch <- unname(Sys.which("sbatch"))
-  if (identical(sbatch, "") || identical(Sys.getenv("METWORX_VERSION"), "")) {
-    skip("not on Metworx with Slurm")
+  if (identical(Sys.getenv("METWORX_VERSION"), "")) {
+    skip("not on Metworx")
+  }
+
+  qsub <- normalizePath(unname(Sys.which("qsub")), mustWork = FALSE)
+  if (!identical(qsub, "/opt/slurm/bin/qsub")) {
+    skip("workflow does not have Slurm's qsub shim")
   }
 
   withr::local_options(list(bbr.DEV_skip_system_mode_checks = FALSE))

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -147,6 +147,21 @@ test_that("submit_model aborts if .mode='sge' and qsub is not available", {
   )
 })
 
+test_that("submit_model aborts if .mode='slurm' and sbatch is not available", {
+  skip_if_old_bbi("3.4.0")
+
+  if (!identical(unname(Sys.which("sbatch")), "")) {
+    skip("sbatch is available")
+  }
+
+  withr::local_options(list(bbr.DEV_skip_system_mode_checks = FALSE))
+
+  expect_error(
+    submit_model(MOD1, .dry_run = TRUE, .mode = "slurm"),
+    regexp = "sbatch is not available"
+  )
+})
+
 test_that("submit_model aborts if .mode='slurm' is used with incompatible bbi", {
   if (test_bbi_version(read_bbi_path(), "3.4.0")) {
     skip("installed bbi version is compatible with Slurm")


### PR DESCRIPTION
 * update test of `.mode="sge"` abort on Slurm workflows for Metworx change

 * when `.model="slurm"` is specified but `sbatch` isn't found, abort upfront rather than leaving it to bbi

 * if either `.mode="sge"` or `.mode="slurm"` is specified but the corresponding executable isn't available, suggest `.mode="local"` in error message
