### PR TITLE
Prepare 1.16.1 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr
 Title: R package for bbi
-Version: 1.16.0
+Version: 1.16.1
 Authors@R: 
     c(person(given = "Seth",
              family = "Green",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# bbr 1.16.1
+
+## Changes
+
+- `submit_model()` aborts when `.mode = "sge"` is specified on a system without
+  `qsub`. That message has been updated to suggest `.mode = "local"`. (#767)
+
+- When `.model = "slurm"` is specified on a system without `sbatch`,
+  `submit_model()` now aborts upfront rather than falling through to bbi's error
+  handling. (#767)
+
+
 # bbr 1.16.0
 
 ## New features


### PR DESCRIPTION
changeset: [1.16.0...release/1.16.1](https://github.com/metrumresearchgroup/bbr/compare/1.16.0...release/1.16.1)

<details>
<summary>scores</summary>

```
$ git rev-parse HEAD^{tree}
db9eabbacd2dcdc2d3d94267201c8c5648b5ccb8
```

```json
{
  "testing": {
    "check": 1,
    "coverage": 0.8374
  },
  "documentation": {
    "has_vignettes": 1,
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```

</details>
